### PR TITLE
fix STUN scheduling

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "engines": {
-    "node": "12 || 14",
+    "node": "14",
     "yarn": "1"
   },
   "files": [
@@ -68,7 +68,10 @@
     "extension": [
       "ts"
     ],
-    "spec": "src/webRTCConnection.spec.ts",
+    "spec": [
+      "src/webRTCConnection.spec.ts",
+      "src/stun.spec.ts"
+    ],
     "require": [
       "ts-node/register"
     ]

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -17,6 +17,7 @@ import Multiaddr from 'multiaddr'
 import { handleStunRequest, getExternalIp } from './stun'
 import { getAddrs, isAnyAddress } from './addrs'
 import { TCPConnection } from './tcp'
+import { once } from 'events'
 
 const log = debug('hopr-connect:listener')
 const error = debug('hopr-connect:listener:error')
@@ -86,16 +87,18 @@ class Listener extends EventEmitter implements InterfaceListener {
     this.state = State.UNINITIALIZED
 
     Promise.all([
-      new Promise((resolve) => this.udpSocket.once('listening', resolve)),
-      new Promise((resolve) => this.tcpSocket.once('listening', resolve))
+      // prettier-ignore
+      once(this.udpSocket, 'listening'),
+      once(this.tcpSocket, 'listening')
     ]).then(() => {
       this.state = State.LISTENING
       this.emit('listening')
     })
 
     Promise.all([
-      new Promise((resolve) => this.udpSocket.once('close', resolve)),
-      new Promise((resolve) => this.tcpSocket.once('close', resolve))
+      // prettier-ignore
+      once(this.udpSocket, 'close'),
+      once(this.tcpSocket, 'close')
     ]).then(() => this.emit('close'))
 
     this.udpSocket.on('message', (msg: Buffer, rinfo: RemoteInfo) => handleStunRequest(this.udpSocket, msg, rinfo))
@@ -185,7 +188,7 @@ class Listener extends EventEmitter implements InterfaceListener {
             }
           )
         } catch (err) {
-          error(`Could bind to TCP socket. Error was: ${err.message}`)
+          error(`Could not bind to TCP socket. ${err.message}`)
           reject()
         }
       })
@@ -200,25 +203,31 @@ class Listener extends EventEmitter implements InterfaceListener {
             },
             async () => {
               this.udpSocket.removeListener('error', reject)
-              try {
-                this.externalAddress = await getExternalIp(this.stunServers, this.udpSocket)
-              } catch (err) {
-                error(`Unable to fetch external address using STUN. Error was: ${err}`)
-              }
+
+              this.externalAddress = await getExternalIp(this.stunServers, this.udpSocket)
+
+              // } catch (err) {
+              //   error(`Unable to fetch external address using STUN. ${err}`)
+              // }
 
               resolve(this.udpSocket.address().port)
             }
           )
         } catch (err) {
-          error(`Could bind UDP socket. Error was: ${err.message}`)
+          error(`Could not bind to UDP socket. ${err.message}`)
           reject()
         }
       })
 
     if (options.port == 0 || options.port == null) {
-      await listenTCP().then((port) => listenUDP(port))
+      const tcpPort = await listenTCP()
+      listenUDP(tcpPort)
     } else {
-      await Promise.all([listenTCP(), listenUDP()])
+      await Promise.all([
+        // prettier-ignore
+        listenTCP(),
+        listenUDP()
+      ])
     }
 
     this.state = State.LISTENING

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -206,10 +206,6 @@ class Listener extends EventEmitter implements InterfaceListener {
 
               this.externalAddress = await getExternalIp(this.stunServers, this.udpSocket)
 
-              // } catch (err) {
-              //   error(`Unable to fetch external address using STUN. ${err}`)
-              // }
-
               resolve(this.udpSocket.address().port)
             }
           )

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -406,7 +406,7 @@ class Relay {
       // Don't catch close errors
       newConn.connection
         ?.close()
-        .catch((err) => error(`Failed to close connection to ${blue(counterparty.toB58String())}. ${err.message}`))
+        .catch((err: any) => error(`Failed to close connection to ${blue(counterparty.toB58String())}. ${err.message}`))
       error(`Error while trying to decode answer from ${blue(counterparty.toB58String())}. Error was: ${err}`)
     }
 
@@ -416,7 +416,7 @@ class Relay {
       // Don't catch close errors
       newConn.connection
         ?.close()
-        .catch((err) => error(`Failed to close connection to ${blue(counterparty.toB58String())}. ${err.message}`))
+        .catch((err: any) => error(`Failed to close connection to ${blue(counterparty.toB58String())}. ${err.message}`))
       error(`Could not relay to ${blue(counterparty.toB58String())} because we are unable to deliver packets.`)
     }
 

--- a/src/stun.ts
+++ b/src/stun.ts
@@ -3,8 +3,10 @@ import * as stun from 'webrtc-stun'
 import type { Socket, RemoteInfo } from 'dgram'
 import Multiaddr from 'multiaddr'
 import debug from 'debug'
+import { randomSubset } from '@hoprnet/hopr-utils'
 
-const error = debug('hopr-connect:error')
+const log = debug('hopr-connect:stun:error')
+const error = debug('hopr-connect:stun:error')
 const verbose = debug('hopr-connect:verbose:stun')
 
 export type Interface = {
@@ -22,10 +24,17 @@ export const STUN_TIMEOUT = 1000
 
 // Only used to determine the external address of the bootstrap server
 export const PUBLIC_STUN_SERVERS = [
+  Multiaddr(`/dns4/stun.l.google.com/udp/19302`),
+  Multiaddr(`/dns4/stun1.l.google.com/udp/19302`),
+  Multiaddr(`/dns4/stun2.l.google.com/udp/19302`),
+  Multiaddr(`/dns4/stun3.l.google.com/udp/19302`),
+  Multiaddr(`/dns4/stun4.l.google.com/udp/19302`),
   Multiaddr(`/dns4/stun.sipgate.net/udp/3478`),
   Multiaddr(`/dns4/stun.callwithus.com/udp/3478`),
   Multiaddr(`/dns4/stun.counterpath.net/udp/3478`)
 ]
+
+export const DEFAULT_PARALLEL_STUN_CALLS = 4
 
 export function handleStunRequest(socket: Socket, data: Buffer, rinfo: RemoteInfo): void {
   const req = stun.createBlank()
@@ -33,7 +42,7 @@ export function handleStunRequest(socket: Socket, data: Buffer, rinfo: RemoteInf
   // Overwrite console.log because 'webrtc-stun' package
   // pollutes console output
   const backup = console.log
-  console.log = () => {}
+  console.log = log
 
   if (req.loadBuffer(data)) {
     // if STUN message is BINDING_REQUEST and valid content
@@ -52,16 +61,19 @@ export function handleStunRequest(socket: Socket, data: Buffer, rinfo: RemoteInf
   console.log = backup
 }
 
-export function getExternalIp(multiAddrs: Multiaddr[] | undefined, socket: Socket): Promise<ConnectionInfo> {
-  return new Promise<ConnectionInfo>((resolve, reject) => {
+export function getExternalIp(
+  multiAddrs: Multiaddr[] | undefined,
+  socket: Socket
+): Promise<ConnectionInfo | undefined> {
+  return new Promise<ConnectionInfo | undefined>((resolve) => {
     if (multiAddrs == undefined || multiAddrs.length == 0) {
-      multiAddrs = PUBLIC_STUN_SERVERS
+      multiAddrs = randomSubset(PUBLIC_STUN_SERVERS, DEFAULT_PARALLEL_STUN_CALLS)
     }
 
     verbose(`Getting external IP by using ${multiAddrs.map((m) => m.toString()).join(',')}`)
     const tids = Array.from({ length: multiAddrs.length }).map(stun.generateTransactionId)
 
-    let result: ConnectionInfo
+    const results: ConnectionInfo[] = []
 
     // @TODO add assert call
     // let _finished = false
@@ -73,61 +85,50 @@ export function getExternalIp(multiAddrs: Multiaddr[] | undefined, socket: Socke
       // Overwrite console.log because 'webrtc-stun' package
       // pollutes console output
       const backup = console.log
-      console.log = () => {}
+      console.log = log
 
-      if (res.loadBuffer(msg)) {
-        let index: number = tids.findIndex((tid: string) => {
-          if (res.isBindingResponseSuccess({ transactionId: tid })) {
-            return true
-          }
-
-          return false
-        })
-
-        if (index >= 0) {
-          tids.splice(index, 1)
-          const attr = res.getXorMappedAddressAttribute() || res.getMappedAddressAttribute()
-
-          if (attr != null) {
-            verbose(`Received STUN response. External address seems to be: ${attr.address}:${attr.port}`)
-
-            if (result == undefined) {
-              result = attr
-            }
-
-            if (tids.length == 0 || attr.port != result.port || attr.address !== result.address) {
-              socket.removeListener('message', msgHandler)
-              // @TODO add assert call
-              // _finished = true
-              clearTimeout(timeout)
-
-              if (attr.address !== result.address || attr.port != result.port) {
-                reject()
-              }
-
-              resolve({
-                address: attr.address,
-                port: attr.port
-              })
-            }
-          } else {
-            error(`STUN response seems to have neither MappedAddress nor XORMappedAddress set. Dropping message`)
-          }
-        } else {
-          error(`Received STUN response with invalid transactionId. Dropping response.`)
-        }
+      if (!res.loadBuffer(msg)) {
+        error(`Could not decode STUN response`)
+        console.log = backup
+        return
       }
+
+      const index: number = tids.findIndex((tid: string) => res.isBindingResponseSuccess({ transactionId: tid }))
+
+      if (index < 0) {
+        error(`Received STUN response with invalid transactionId. Dropping response.`)
+        console.log = backup
+        return
+      }
+
+      tids.splice(index, 1)
+      const attr = res.getXorMappedAddressAttribute() ?? res.getMappedAddressAttribute()
+
+      if (attr == null) {
+        error(`STUN response seems to have neither MappedAddress nor XORMappedAddress set. Dropping message`)
+        console.log = backup
+        return
+      }
+
+      verbose(`Received STUN response. External address seems to be: ${attr.address}:${attr.port}`)
+
+      if (results.push(attr) == multiAddrs?.length) {
+        done()
+      }
+
       console.log = backup
     }
+
+    const errHandler = (err: any) => {
+      verbose('STUN error', err)
+    }
+
     socket.on('message', msgHandler)
-    socket.on('error', (err) => {
-      verbose('Err:', err)
-      reject(err)
-    })
+    socket.on('error', errHandler)
 
     multiAddrs.forEach((ma: Multiaddr, index: number) => {
       if (!['ip4', 'ip6', 'dns4', 'dns6'].includes(ma.protoNames()[0])) {
-        error(`Cannot contact STUN server ${ma.toString()} because the host is unknown.`)
+        error(`Cannot contact STUN server ${ma.toString()} due invalid address.`)
         return
       }
 
@@ -140,15 +141,30 @@ export function getExternalIp(multiAddrs: Multiaddr[] | undefined, socket: Socke
       socket.send(res.toBuffer(), nodeAddress.port as any, nodeAddress.address)
     })
 
-    timeout = setTimeout(() => {
+    const done = () => {
       socket.removeListener('message', msgHandler)
-      // @TODO add assert call
-      // _finished = true
-      if (result == undefined) {
-        reject(Error(`Timeout. Could not complete STUN request in time.`))
-      } else {
-        resolve(result)
+      socket.removeListener('error', errHandler)
+
+      clearTimeout(timeout)
+
+      if (results.length == 0) {
+        error(`STUN Timeout. Could not complete STUN request in time.`)
       }
-    }, STUN_TIMEOUT)
+
+      if (results.length == 1) {
+        resolve(results[0])
+        return
+      }
+
+      for (const result of results) {
+        if (result.port != results[0].port) {
+          return resolve(undefined)
+        }
+      }
+
+      resolve(results[0])
+    }
+
+    timeout = setTimeout(() => done(), STUN_TIMEOUT)
   })
 }


### PR DESCRIPTION
Changes the STUN code to perform STUN request concurrently and independent from each other.

`getExternalIp` returns `undefined` if all STUN requests timeout or the STUN request show different ports (== bidirectional NAT)