### PR TITLE
Don't emit events before corresponding method has finished

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     ],
     "spec": [
       "src/webRTCConnection.spec.ts",
-      "src/stun.spec.ts"
+      "src/stun.spec.ts",
+      "src/listener.spec.ts"
     ],
     "require": [
       "ts-node/register"

--- a/src/listener.spec.ts
+++ b/src/listener.spec.ts
@@ -194,7 +194,7 @@ describe('transport/listener.spec check listening to sockets', function () {
     await listener.close()
   })
 
-  it('should do a STUN request', async function () {
+  it('should perform a STUN request', async function () {
     const defer = Defer<void>()
     const listener = new Listener(
       (conn: Connection) => {

--- a/src/listener.spec.ts
+++ b/src/listener.spec.ts
@@ -16,7 +16,7 @@ import * as stun from 'webrtc-stun'
 
 import { networkInterfaces } from 'os'
 
-describe('transport/listener.spec check listening to sockets', function () {
+describe('check listening to sockets', function () {
   this.timeout(5000)
   async function startStunServer(port: number, state: { msgReceived: DeferredPromise<void> }): Promise<Socket> {
     const promises: Promise<void>[] = []
@@ -236,14 +236,14 @@ describe('transport/listener.spec check listening to sockets', function () {
 
     const addrs = listener.getAddrs()
 
-    const cOpts = addrs[1].toOptions()
+    const localAddress = addrs.find((ma: Multiaddr) => ma.toString().match(/127.0.0.1/))
 
-    socket.send(req.toBuffer(), cOpts.port, `localhost`)
+    assert(localAddress != null, `Listener must be available on localhost`)
 
-    await new Promise((resolve) => setTimeout(resolve, 100))
-
-    await listener.close()
+    socket.send(req.toBuffer(), localAddress.toOptions().port, `localhost`)
 
     await defer.promise
+
+    await listener.close()
   })
 })

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -88,15 +88,6 @@ class Listener extends EventEmitter implements InterfaceListener {
 
     Promise.all([
       // prettier-ignore
-      once(this.udpSocket, 'listening'),
-      once(this.tcpSocket, 'listening')
-    ]).then(() => {
-      this.state = State.LISTENING
-      this.emit('listening')
-    })
-
-    Promise.all([
-      // prettier-ignore
       once(this.udpSocket, 'close'),
       once(this.tcpSocket, 'close')
     ]).then(() => this.emit('close'))
@@ -217,7 +208,7 @@ class Listener extends EventEmitter implements InterfaceListener {
 
     if (options.port == 0 || options.port == null) {
       const tcpPort = await listenTCP()
-      listenUDP(tcpPort)
+      await listenUDP(tcpPort)
     } else {
       await Promise.all([
         // prettier-ignore
@@ -227,6 +218,7 @@ class Listener extends EventEmitter implements InterfaceListener {
     }
 
     this.state = State.LISTENING
+    this.emit('listening')
   }
 
   async close(): Promise<void> {


### PR DESCRIPTION
Fixes:
- don't emit Listener `listen` event before Listener.listen() has returned
- don't emit Listener `close` event before Listener.close() was called and the call has returned
- produce tracebacks on unexpected socket `close` events