### PR TITLE
bugfixes & more tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,10 +68,12 @@
       "ts"
     ],
     "spec": [
+      "src/addrs.spec.ts",
       "src/filter.spec.ts",
       "src/webRTCConnection.spec.ts",
       "src/stun.spec.ts",
-      "src/listener.spec.ts"
+      "src/listener.spec.ts",
+      "src/utils/*.spec.ts"
     ],
     "require": [
       "ts-node/register"

--- a/src/addrs.spec.ts
+++ b/src/addrs.spec.ts
@@ -1,0 +1,83 @@
+import { getAddrs } from './addrs'
+import PeerId from 'peer-id'
+import assert from 'assert'
+import { networkInterfaces } from 'os'
+
+describe('addrs', function () {
+  let pId: PeerId
+  const INVALID_NETWORK_INTERFACE = Object.keys(networkInterfaces()).join().concat(`foo`)
+  const VALID_NETWORK_INTERFACE = Object.keys(networkInterfaces())[0]
+
+  before(async function () {
+    pId = await PeerId.create({ keyType: 'secp256k1' })
+  })
+
+  it('should understand network interface', function () {
+    assert(
+      getAddrs(9091, pId.toB58String(), {
+        interface: INVALID_NETWORK_INTERFACE,
+        useIPv4: true,
+        includeLocalhostIPv4: true
+      }).length == 0,
+      'Should not output any addresses if the specified network interface does not exist'
+    )
+
+    assert(
+      getAddrs(9091, pId.toB58String(), {
+        interface: VALID_NETWORK_INTERFACE,
+        useIPv4: true,
+        useIPv6: true,
+        includeLocalhostIPv4: true,
+        includeLocalhostIPv6: true,
+        includePrivateIPv4: true
+      }).length >= 1,
+      'Should output at least one address if the specified network interface exists'
+    )
+  })
+
+  it('should get IPv4 address', function () {
+    assert(
+      getAddrs(
+        9091,
+        pId.toB58String(),
+        {
+          useIPv6: true,
+          useIPv4: true,
+          includeLocalhostIPv4: true,
+          includeLocalhostIPv6: true,
+          includePrivateIPv4: true
+        },
+        {
+          myFakeInterface: [
+            {
+              address: 'fe80::cdc2:2079:792:3d33',
+              netmask: 'ffff:ffff:ffff:ffff::',
+              family: 'IPv6'
+            } as any
+          ]
+        }
+      ).length == 0,
+      `Should not use link-locale addresses`
+    )
+
+    assert(
+      getAddrs(
+        9091,
+        pId.toB58String(),
+        {
+          useIPv4: true
+        },
+        {
+          myFakeInterface: [
+            {
+              address: '10.0.27.191',
+              netmask: '255.0.0.0',
+              family: 'IPv4'
+            } as any
+          ]
+        }
+      ).length == 0,
+      `Should not include private IPv4 addresses`
+    )
+  })
+})

--- a/src/addrs.spec.ts
+++ b/src/addrs.spec.ts
@@ -35,7 +35,7 @@ describe('addrs', function () {
     )
   })
 
-  it('should get IPv4 address', function () {
+  it('should get ip address', function () {
     assert(
       getAddrs(
         9091,
@@ -79,9 +79,29 @@ describe('addrs', function () {
       ).length == 0,
       `Should not include private IPv4 addresses`
     )
+
+    assert(
+      getAddrs(
+        9091,
+        pId.toB58String(),
+        {
+          useIPv4: true
+        },
+        {
+          myFakeInterface: [
+            {
+              address: '2001:db8:0:0:0:0:1428:57ab',
+              netmask: 'ffff:ffff:ffff:ffff::',
+              family: 'IPv6'
+            } as any
+          ]
+        }
+      ).length == 0,
+      `Should not include IPv6 addresses when searching for IPv4 addresses`
+    )
   })
 
-  it('try configuration edge case', function () {
+  it('try configuration edge cases', function () {
     assert.throws(() =>
       getAddrs(12345, pId.toB58String(), {
         useIPv4: false,
@@ -95,5 +115,7 @@ describe('addrs', function () {
         includeLocalhostIPv6: true
       })
     )
+
+    assert.throws(() => getAddrs(12345, pId.toB58String(), {}))
   })
 })

--- a/src/addrs.spec.ts
+++ b/src/addrs.spec.ts
@@ -80,4 +80,20 @@ describe('addrs', function () {
       `Should not include private IPv4 addresses`
     )
   })
+
+  it('try configuration edge case', function () {
+    assert.throws(() =>
+      getAddrs(12345, pId.toB58String(), {
+        useIPv4: false,
+        includeLocalhostIPv4: true
+      })
+    )
+
+    assert.throws(() =>
+      getAddrs(12345, pId.toB58String(), {
+        useIPv6: false,
+        includeLocalhostIPv6: true
+      })
+    )
+  })
 })

--- a/src/addrs.ts
+++ b/src/addrs.ts
@@ -19,6 +19,11 @@ function validateOptions(opts?: AddrOptions) {
   if (opts == undefined) {
     return
   }
+
+  if (opts.useIPv4 != true && opts.useIPv6 != true) {
+    throw Error(`Must use either IPv4 or IPv6 but cannot use none.`)
+  }
+
   if (opts.useIPv4 == false && (opts.includePrivateIPv4 || opts.includeLocalhostIPv4)) {
     throw Error(`Contradiction in opts. Cannot add private or local IPv4 address if IPv4 is disabled.`)
   }

--- a/src/addrs.ts
+++ b/src/addrs.ts
@@ -15,7 +15,7 @@ type AddrOptions = {
   includeLocalhostIPv6?: boolean
 }
 
-function validateOptions(opts?: AddrOptions) {
+function validateOptions(opts: AddrOptions) {
   if (opts == undefined) {
     return
   }
@@ -54,7 +54,9 @@ export function getAddrs(
   options?: AddrOptions,
   __fakeInterfaces?: ReturnType<typeof networkInterfaces>
 ) {
-  validateOptions(options)
+  if (options) {
+    validateOptions(options)
+  }
 
   let interfaces: (NetworkInterfaceInfo[] | undefined)[]
 

--- a/src/addrs.ts
+++ b/src/addrs.ts
@@ -29,7 +29,7 @@ function validateOptions(opts: AddrOptions) {
   }
 
   if (opts.useIPv6 == false && opts.includeLocalhostIPv6) {
-    throw Error(`Contradiction in opts. Cannot add private or local IPv4 address if IPv4 is disabled.`)
+    throw Error(`Contradiction in opts. Cannot add private or local IPv6 address if IPv6 is disabled.`)
   }
 }
 

--- a/src/addrs.ts
+++ b/src/addrs.ts
@@ -1,40 +1,62 @@
 import { networkInterfaces, NetworkInterfaceInfo } from 'os'
-import { nodeToMultiaddr } from './utils'
+import { isLinkLocaleAddress, nodeToMultiaddr } from './utils'
 import { Multiaddr } from 'multiaddr'
 import Debug from 'debug'
 const log = Debug('hopr-connect')
 
 import { isLocalhost, ipToU8aAddress, isPrivateAddress } from './utils'
 
+type AddrOptions = {
+  interface?: string
+  useIPv4?: boolean
+  useIPv6?: boolean
+  includePrivateIPv4?: boolean
+  includeLocalhostIPv4?: boolean
+  includeLocalhostIPv6?: boolean
+}
+
+function validateOptions(opts?: AddrOptions) {
+  if (opts == undefined) {
+    return
+  }
+  if (opts.useIPv4 == false && (opts.includePrivateIPv4 || opts.includeLocalhostIPv4)) {
+    throw Error(`Contradiction in opts. Cannot add private or local IPv4 address if IPv4 is disabled.`)
+  }
+
+  if (opts.useIPv6 == false && opts.includeLocalhostIPv6) {
+    throw Error(`Contradiction in opts. Cannot add private or local IPv4 address if IPv4 is disabled.`)
+  }
+}
+
+function getAddrsOfInterface(iface: string) {
+  let ifaceAddrs = networkInterfaces()[iface]
+
+  if (ifaceAddrs == undefined) {
+    log(
+      `Interface <${iface}> does not exist on this machine. Available are <${Object.keys(networkInterfaces()).join(
+        ', '
+      )}>`
+    )
+    return []
+  }
+
+  return ifaceAddrs
+}
+
 export function getAddrs(
   port: number,
   peerId: string,
-  options?: {
-    interface?: string
-    useIPv4?: boolean
-    useIPv6?: boolean
-    includeLocalIPv4?: boolean
-    includeLocalIPv6?: boolean
-    includeLocalhostIPv4?: boolean
-    includeLocalhostIPv6?: boolean
-  }
+  options?: AddrOptions,
+  __fakeInterfaces?: ReturnType<typeof networkInterfaces>
 ) {
+  validateOptions(options)
+
   let interfaces: (NetworkInterfaceInfo[] | undefined)[]
 
-  if (options?.interface != undefined) {
-    let _tmp = networkInterfaces()[options.interface]
-
-    if (_tmp == undefined) {
-      log(
-        `Interface <${options.interface}> does not exist on this machine. Available are <${Object.keys(
-          networkInterfaces()
-        ).join(', ')}>`
-      )
-      return []
-    }
-    interfaces = [_tmp]
+  if (options?.interface) {
+    interfaces = [getAddrsOfInterface(options.interface)]
   } else {
-    interfaces = Object.values(networkInterfaces())
+    interfaces = Object.values(__fakeInterfaces ?? networkInterfaces())
   }
 
   const multiaddrs: Multiaddr[] = []
@@ -46,11 +68,13 @@ export function getAddrs(
 
     for (const address of iface) {
       const u8aAddr = ipToU8aAddress(address.address, address.family)
+
+      if (isLinkLocaleAddress(u8aAddr, address.family)) {
+        continue
+      }
+
       if (isPrivateAddress(u8aAddr, address.family)) {
-        if (address.family === 'IPv4' && (options == undefined || options.includeLocalIPv4 != true)) {
-          continue
-        }
-        if (address.family === 'IPv6' && (options == undefined || options.includeLocalIPv6 != true)) {
+        if (address.family === 'IPv4' && (options == undefined || options.includePrivateIPv4 != true)) {
           continue
         }
       }
@@ -64,11 +88,11 @@ export function getAddrs(
         }
       }
 
-      if (address.family === 'IPv4' && options != undefined && options.useIPv4 == false) {
+      if (address.family === 'IPv4' && options != undefined && options.useIPv4 != true) {
         continue
       }
 
-      if (address.family === 'IPv6' && options != undefined && options.useIPv6 == false) {
+      if (address.family === 'IPv6' && options != undefined && options.useIPv6 != true) {
         continue
       }
 

--- a/src/addrs.ts
+++ b/src/addrs.ts
@@ -51,12 +51,10 @@ function getAddrsOfInterface(iface: string) {
 export function getAddrs(
   port: number,
   peerId: string,
-  options?: AddrOptions,
+  options: AddrOptions,
   __fakeInterfaces?: ReturnType<typeof networkInterfaces>
 ) {
-  if (options) {
-    validateOptions(options)
-  }
+  validateOptions(options)
 
   let interfaces: (NetworkInterfaceInfo[] | undefined)[]
 
@@ -81,25 +79,25 @@ export function getAddrs(
       }
 
       if (isPrivateAddress(u8aAddr, address.family)) {
-        if (address.family === 'IPv4' && (options == undefined || options.includePrivateIPv4 != true)) {
+        if (address.family === 'IPv4' && options.includePrivateIPv4 != true) {
           continue
         }
       }
 
       if (isLocalhost(u8aAddr, address.family)) {
-        if (address.family === 'IPv4' && (options == undefined || options.includeLocalhostIPv4 != true)) {
+        if (address.family === 'IPv4' && options.includeLocalhostIPv4 != true) {
           continue
         }
-        if (address.family === 'IPv6' && (options == undefined || options.includeLocalhostIPv6 != true)) {
+        if (address.family === 'IPv6' && options.includeLocalhostIPv6 != true) {
           continue
         }
       }
 
-      if (address.family === 'IPv4' && options != undefined && options.useIPv4 != true) {
+      if (address.family === 'IPv4' && options.useIPv4 != true) {
         continue
       }
 
-      if (address.family === 'IPv6' && options != undefined && options.useIPv6 != true) {
+      if (address.family === 'IPv6' && options.useIPv6 != true) {
         continue
       }
 

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -248,9 +248,9 @@ class Listener extends EventEmitter implements InterfaceListener {
 
     addrs.push(
       ...getAddrs(address.port, this.peerId.toB58String(), {
+        useIPv4: true,
         includePrivateIPv4: true,
-        includeLocalhostIPv4: true,
-        useIPv6: false
+        includeLocalhostIPv4: true
       })
     )
 

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -248,7 +248,7 @@ class Listener extends EventEmitter implements InterfaceListener {
 
     addrs.push(
       ...getAddrs(address.port, this.peerId.toB58String(), {
-        includeLocalIPv4: true,
+        includePrivateIPv4: true,
         includeLocalhostIPv4: true,
         useIPv6: false
       })

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -51,13 +51,15 @@ export const LINK_LOCAL_NETWORKS: Network[] = [
 ]
 
 // Only useful when running > 1 instances on the same host
-export const LOCALHOST_ADDRS: Address[] = [
+export const LOCALHOST_ADDRS: Network[] = [
   {
-    address: Uint8Array.from([127, 0, 0, 1]),
+    subnet: Uint8Array.from([255, 0, 0, 0]),
+    networkPrefix: Uint8Array.from([127, 0, 0, 0]),
     family: 'IPv4'
   },
   {
-    address: Uint8Array.from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
+    subnet: Uint8Array.from([255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 254]),
+    networkPrefix: Uint8Array.from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
     family: 'IPv6'
   }
 ]

--- a/src/utils/network.spec.ts
+++ b/src/utils/network.spec.ts
@@ -2,14 +2,22 @@ import {
   ipToU8aAddress,
   getNetworkPrefix,
   inSameNetwork,
-  u8aAddrToString
-  // getLocalAddresses, getLocalHosts, getPublicAddresses
+  u8aAddrToString,
+  getPrivateAddresses,
+  isPrivateAddress,
+  getLocalAddresses,
+  getLocalHosts,
+  isLinkLocaleAddress,
+  isLocalhost,
+  getPublicAddresses
 } from '.'
+import type { Network } from './constants'
 import { u8aEquals } from '@hoprnet/hopr-utils'
 import assert from 'assert'
+import {} from './network'
 
 describe('test utils', function () {
-  it.skip('should convert ip addresses', function () {
+  it('should convert ip addresses', function () {
     assert(u8aEquals(Uint8Array.from([1, 1, 1, 1]), ipToU8aAddress('1.1.1.1', 'IPv4')))
 
     assert(u8aEquals(Uint8Array.from([1, 1, 0, 1]), ipToU8aAddress('1.1.0.1', 'IPv4')))
@@ -55,7 +63,7 @@ describe('test utils', function () {
     )
   })
 
-  it.skip('should return a network prefix', function () {
+  it('should return a network prefix', function () {
     const address4 = ipToU8aAddress('192.168.1.23', 'IPv4')
 
     const subnet4_1 = ipToU8aAddress('255.255.255.0', 'IPv4')
@@ -85,7 +93,7 @@ describe('test utils', function () {
     )
   })
 
-  it.skip('should be in subnet', function () {
+  it('should be in subnet', function () {
     const address = ipToU8aAddress('192.0.2.130', 'IPv4')
     const subnet = ipToU8aAddress('255.255.255.0', 'IPv4')
 
@@ -108,7 +116,7 @@ describe('test utils', function () {
     )
 
     assert(
-      'ffff:ffff:ffff::ffff:ffff:ffff:0000' ===
+      'ffff:ffff:ffff:ffff:ffff:ffff:ffff:0000' ===
         u8aAddrToString(
           Uint8Array.from([255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 0, 0]),
           'IPv6'
@@ -116,9 +124,23 @@ describe('test utils', function () {
     )
   })
 
-  //   it('should get my addresses in a structured way', function () {
-  //     console.log(`localHost`, getLocalHosts())
-  //     console.log(`localAddresses`, getLocalAddresses())
-  //     console.log(`public addresses`, getPublicAddresses())
-  //   })
+  it('should detect private networks', function () {
+    assert(isPrivateAddress(ipToU8aAddress('192.168.1.131', 'IPv4'), 'IPv4'))
+    assert(isPrivateAddress(ipToU8aAddress('10.0.27.191', 'IPv4'), 'IPv4'))
+    assert(!isPrivateAddress(ipToU8aAddress('172.15.0.131', 'IPv4'), 'IPv4'))
+  })
+
+  it('should detect local addresses as local', function () {
+    assert(getLocalHosts().every((network: Network) => isLocalhost(network.networkPrefix, network.family)))
+    assert(getPrivateAddresses().every((network: Network) => isPrivateAddress(network.networkPrefix, network.family)))
+    assert(getLocalAddresses().every((network: Network) => isLinkLocaleAddress(network.networkPrefix, network.family)))
+    assert(
+      getPublicAddresses().every(
+        (network: Network) =>
+          !isLocalhost(network.networkPrefix, network.family) &&
+          !isPrivateAddress(network.networkPrefix, network.family) &&
+          !isLinkLocaleAddress(network.networkPrefix, network.family)
+      )
+    )
+  })
 })

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -1,4 +1,4 @@
-import { stringToU8a, u8aEquals, u8aToHex } from '@hoprnet/hopr-utils'
+import { stringToU8a, u8aToHex } from '@hoprnet/hopr-utils'
 import type { Network } from './constants'
 import { PRIVATE_NETWORK, LINK_LOCAL_NETWORKS, LOCALHOST_ADDRS } from './constants'
 
@@ -16,12 +16,7 @@ export function isAnyAddress(address: string, family: NetworkInterfaceInfo['fami
 }
 
 export function isLocalhost(address: Uint8Array, family: NetworkInterfaceInfo['family']) {
-  for (const addr of LOCALHOST_ADDRS) {
-    if (addr.family === family && u8aEquals(address, addr.address)) {
-      return true
-    }
-  }
-  return false
+  return checkNetworks(LOCALHOST_ADDRS, address, family)
 }
 
 export function isPrivateAddress(address: Uint8Array, family: NetworkInterfaceInfo['family']) {
@@ -169,6 +164,9 @@ function getAddresses(cond: (address: Uint8Array, family: 'IPv4' | 'IPv6') => bo
   return result
 }
 
+export function getPrivateAddresses(_iface?: string) {
+  return getAddresses(isPrivateAddress)
+}
 export function getLocalAddresses(_iface?: string): Network[] {
   return getAddresses(isLinkLocaleAddress)
 }
@@ -176,7 +174,7 @@ export function getLocalAddresses(_iface?: string): Network[] {
 export function getPublicAddresses(_iface?: string): Network[] {
   return getAddresses(
     (address: Uint8Array, family: 'IPv4' | 'IPv6') =>
-      !isLinkLocaleAddress(address, family) && !isLocalhost(address, family)
+      !isPrivateAddress(address, family) && !isLinkLocaleAddress(address, family) && !isLocalhost(address, family)
   )
 }
 


### PR DESCRIPTION
- improve testing of network interface detection
- fix: not considering private addresses as public addresses
- fix: remove private IPv6 address support because not part of IPv6 specification
- consider 127.0.0.0/8 as loopback and not only 127.0.0.1

most likely solves: hoprnet/hoprnet#1503