### PR TITLE
hotfix stun code

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,6 +10,9 @@ export const NAME = name.replace(/@[a-zA-z0-9\-]+\//, '')
 export const CODE_P2P = Multiaddr.protocols.names['p2p'].code
 export const CODE_IP4 = Multiaddr.protocols.names['ip4'].code
 export const CODE_IP6 = Multiaddr.protocols.names['ip6'].code
+export const CODE_DNS4 = Multiaddr.protocols.names['dns4'].code
+export const CODE_DNS6 = Multiaddr.protocols.names['dns6'].code
+
 export const CODE_CIRCUIT = Multiaddr.protocols.names['p2p-circuit'].code
 export const CODE_TCP = Multiaddr.protocols.names['tcp'].code
 

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -359,7 +359,11 @@ class Listener extends EventEmitter implements InterfaceListener {
             return cOpts.host !== host || cOpts.port !== port
           })
 
-    this.externalAddress = await getExternalIp(usableStunServers, this.udpSocket)
+    try {
+      this.externalAddress = await getExternalIp(usableStunServers, this.udpSocket)
+    } catch (err) {
+      error(err.message)
+    }
 
     return this.udpSocket.address().port
   }

--- a/src/stun.ts
+++ b/src/stun.ts
@@ -4,6 +4,7 @@ import type { Socket, RemoteInfo } from 'dgram'
 import { Multiaddr } from 'multiaddr'
 import debug from 'debug'
 import { randomSubset } from '@hoprnet/hopr-utils'
+import { CODE_IP4, CODE_IP6, CODE_DNS4, CODE_DNS6 } from './constants'
 
 const log = debug('hopr-connect:stun:error')
 const error = debug('hopr-connect:stun:error')
@@ -30,8 +31,7 @@ export const PUBLIC_STUN_SERVERS = [
   new Multiaddr(`/dns4/stun3.l.google.com/udp/19302`),
   new Multiaddr(`/dns4/stun4.l.google.com/udp/19302`),
   new Multiaddr(`/dns4/stun.sipgate.net/udp/3478`),
-  new Multiaddr(`/dns4/stun.callwithus.com/udp/3478`),
-  new Multiaddr(`/dns4/stun.counterpath.net/udp/3478`)
+  new Multiaddr(`/dns4/stun.callwithus.com/udp/3478`)
 ]
 
 export const DEFAULT_PARALLEL_STUN_CALLS = 4
@@ -78,17 +78,45 @@ export function getExternalIp(
   multiAddrs: Multiaddr[] | undefined,
   socket: Socket
 ): Promise<ConnectionInfo | undefined> {
-  return new Promise<ConnectionInfo | undefined>((resolve) => {
+  return new Promise<ConnectionInfo | undefined>(async (resolve, reject) => {
+    let usableMultiaddrs: Multiaddr[]
     if (multiAddrs == undefined || multiAddrs.length == 0) {
-      multiAddrs = randomSubset(PUBLIC_STUN_SERVERS, DEFAULT_PARALLEL_STUN_CALLS)
+      usableMultiaddrs = randomSubset(PUBLIC_STUN_SERVERS, DEFAULT_PARALLEL_STUN_CALLS)
+    } else {
+      usableMultiaddrs = multiAddrs
     }
 
-    verbose(`Getting external IP by using ${multiAddrs.map((m) => m.toString()).join(',')}`)
-    const tids = Array.from({ length: multiAddrs.length }).map(stun.generateTransactionId)
+    verbose(`Getting external IP by using ${usableMultiaddrs.map((m) => m.toString()).join(',')}`)
+    const tids = Array.from({ length: usableMultiaddrs.length }).map(stun.generateTransactionId)
 
     const results: ConnectionInfo[] = []
 
     let timeout: NodeJS.Timeout
+
+    const done = () => {
+      socket.removeListener('message', msgHandler)
+
+      clearTimeout(timeout)
+
+      if (results.length == 0) {
+        error(`STUN Timeout. Could not complete STUN request in time.`)
+        resolve(undefined)
+        return
+      }
+
+      if (results.length == 1) {
+        resolve(results[0])
+        return
+      }
+
+      for (const result of results) {
+        if (result.port != results[0].port) {
+          return resolve(undefined)
+        }
+      }
+
+      resolve(results[0])
+    }
 
     const msgHandler = (msg: Buffer) => {
       const res = stun.createBlank()
@@ -115,67 +143,71 @@ export function getExternalIp(
       tids.splice(index, 1)
       const attr = res.getXorMappedAddressAttribute() ?? res.getMappedAddressAttribute()
 
+      console.log = backup
+
       if (attr == null) {
         error(`STUN response seems to have neither MappedAddress nor XORMappedAddress set. Dropping message`)
-        console.log = backup
         return
       }
 
       verbose(`Received STUN response. External address seems to be: ${attr.address}:${attr.port}`)
 
-      if (results.push(attr) == multiAddrs?.length) {
+      if (results.push(attr) == usableMultiaddrs.length) {
         done()
       }
-
-      console.log = backup
-    }
-
-    const errHandler = (err: any) => {
-      verbose('STUN error', err)
     }
 
     socket.on('message', msgHandler)
-    socket.on('error', errHandler)
 
-    for (const [index, ma] of multiAddrs.entries()) {
-      if (!['ip4', 'ip6', 'dns4', 'dns6'].includes(ma.protoNames()[0])) {
-        error(`Cannot contact STUN server ${ma.toString()} due invalid address.`)
-        return
+    const allSent = performStunRequests(usableMultiaddrs, tids, socket)
+
+    if (allSent.length > 0) {
+      const sendResults = await Promise.all(allSent)
+
+      if (!sendResults.some((result) => result)) {
+        reject(
+          new Error(
+            `Cannot send any STUN packets. Tried with: ${usableMultiaddrs
+              .map((ma: Multiaddr) => ma.toString())
+              .join(', ')}`
+          )
+        )
       }
 
-      const nodeAddress = ma.nodeAddress()
-
-      const res = stun.createBindingRequest(tids[index]).setFingerprintAttribute()
-
-      verbose(`STUN request sent to ${nodeAddress.address}:${nodeAddress.port}`)
-
-      socket.send(res.toBuffer(), nodeAddress.port, nodeAddress.address)
+      timeout = setTimeout(() => done(), STUN_TIMEOUT)
+    } else {
+      reject(new Error(`Cannot detect external IP address using STUN`))
     }
-
-    const done = () => {
-      socket.removeListener('message', msgHandler)
-      socket.removeListener('error', errHandler)
-
-      clearTimeout(timeout)
-
-      if (results.length == 0) {
-        error(`STUN Timeout. Could not complete STUN request in time.`)
-      }
-
-      if (results.length == 1) {
-        resolve(results[0])
-        return
-      }
-
-      for (const result of results) {
-        if (result.port != results[0].port) {
-          return resolve(undefined)
-        }
-      }
-
-      resolve(results[0])
-    }
-
-    timeout = setTimeout(() => done(), STUN_TIMEOUT)
   })
+}
+
+function performStunRequests(usableMultiaddrs: Multiaddr[], tIds: string[], socket: Socket): Promise<boolean>[] {
+  const result: Promise<boolean>[] = []
+
+  for (const [index, ma] of usableMultiaddrs.entries()) {
+    if (![CODE_IP4, CODE_IP6, CODE_DNS4, CODE_DNS6].includes(ma.tuples()[0][0])) {
+      error(`Cannot contact STUN server ${ma.toString()} due invalid address.`)
+      continue
+    }
+
+    const nodeAddress = ma.nodeAddress()
+
+    const res = stun.createBindingRequest(tIds[index]).setFingerprintAttribute()
+
+    verbose(`STUN request sent to ${nodeAddress.address}:${nodeAddress.port}`)
+
+    result.push(
+      new Promise<boolean>((resolve) => {
+        socket.send(res.toBuffer(), nodeAddress.port, nodeAddress.address, (err: any) => {
+          if (err) {
+            resolve(false)
+          } else {
+            resolve(true)
+          }
+        })
+      })
+    )
+  }
+
+  return result
 }


### PR DESCRIPTION
Fixes:
- do not fail on DNS failures during STUN requests to external STUN servers
- properly recover console.log when handling STUN requests
- fail early if no STUN server is reachable

Fixes #180 