### PR TITLE
limit STUN requests to reasonable amount

### DIFF
--- a/src/stun.spec.ts
+++ b/src/stun.spec.ts
@@ -132,7 +132,7 @@ describe('test STUN', function () {
     }
 
     assert(
-      servers.some((server: ServerType) => contactedIndices.includes(server.index) && server.contactCount == 0),
+      servers.some((server: ServerType) => !contactedIndices.includes(server.index) && server.contactCount == 0),
       `At least one server should not have been contacted`
     )
   })

--- a/src/stun.spec.ts
+++ b/src/stun.spec.ts
@@ -116,7 +116,7 @@ describe('test STUN', function () {
 
     const stunResult = await getExternalIp(multiaddrs, servers[0].socket)
 
-    assert(stunResult != undefined)
+    assert(stunResult != undefined, `STUN requests must lead to a result`)
 
     let contactedPromises = servers.slice(1).map((server) => server.gotContacted.promise)
     const contactedIndices: number[] = []

--- a/src/stun.spec.ts
+++ b/src/stun.spec.ts
@@ -19,6 +19,9 @@ describe('test STUN', function () {
 
   before(async () => {
     servers = await Promise.all(
+      // 1 STUN server that contacts
+      // DEFAULT_PARALLEL_STUN_CALLS STUN servers and leaves out
+      // 1 available STUN server
       Array.from({ length: DEFAULT_PARALLEL_STUN_CALLS + 2 }).map(
         (_: any, index: number) =>
           new Promise<ServerType>((resolve, reject) => {

--- a/src/stun.ts
+++ b/src/stun.ts
@@ -82,6 +82,8 @@ export function getExternalIp(
     let usableMultiaddrs: Multiaddr[]
     if (multiAddrs == undefined || multiAddrs.length == 0) {
       usableMultiaddrs = randomSubset(PUBLIC_STUN_SERVERS, DEFAULT_PARALLEL_STUN_CALLS)
+    } else if (multiAddrs.length > DEFAULT_PARALLEL_STUN_CALLS) {
+      usableMultiaddrs = randomSubset(multiAddrs, DEFAULT_PARALLEL_STUN_CALLS)
     } else {
       usableMultiaddrs = multiAddrs
     }


### PR DESCRIPTION
Current behavior:
- STUN code uses *all* available STUN server, might be a lot of nodes

New behavior:
- Contact only a few and choose them randomly