### PR TITLE
less scary tcp failures

### DIFF
--- a/src/tcp.ts
+++ b/src/tcp.ts
@@ -103,11 +103,10 @@ class TCPConnection implements MultiaddrConnection {
   }
 
   private async _sink(source: Stream['source']): Promise<void> {
+    const u8aStream = toU8aStream(source)
     try {
       await this._stream.sink(
-        this._signal != undefined
-          ? (abortable(toU8aStream(source), this._signal) as Stream['source'])
-          : toU8aStream(source)
+        this._signal != undefined ? (abortable(u8aStream, this._signal) as Stream['source']) : u8aStream
       )
     } catch (err) {
       // If aborted we can safely ignore
@@ -142,7 +141,7 @@ class TCPConnection implements MultiaddrConnection {
       })
 
       const onError = (err: Error) => {
-        verbose('Error connecting:', err)
+        verbose('Error connecting:', err.message)
         // ENETUNREACH
         // ECONNREFUSED
         // @TODO check error(s)


### PR DESCRIPTION
Changes:
- minor refactoring

Current behavior:
- unsuccessful TCP connect attempts fail with
```
  hopr-connect:verbose:tcp Error connecting: Error: connect EHOSTUNREACH 93.109.146.190:9091
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1146:16) {
  errno: -113,
  code: 'EHOSTUNREACH',
  syscall: 'connect',
  address: '93.109.146.190',
  port: 9091
} +41ms
```

New behavior:
- reduced debug output
```
  hopr-connect:verbose:tcp Error connecting: Error: connect EHOSTUNREACH 93.109.146.190:9091
```