### PR TITLE
Improve listening sequence

### DIFF
--- a/src/listener.spec.ts
+++ b/src/listener.spec.ts
@@ -35,13 +35,13 @@ describe('check listening to sockets', function () {
         socket.removeListener('listening', resolve)
         reject(err)
       })
-      socket.once('listening', resolve)
+      socket.once('listening', () => {
+        socket.removeListener('error', reject)
+        resolve()
+      })
 
       try {
-        socket.bind(port, () => {
-          socket.removeListener('error', reject)
-          resolve()
-        })
+        socket.bind(port)
       } catch (err) {
         reject(err)
       }

--- a/src/listener.spec.ts
+++ b/src/listener.spec.ts
@@ -13,6 +13,7 @@ import net from 'net'
 import Defer from 'p-defer'
 import type { DeferredPromise } from 'p-defer'
 import * as stun from 'webrtc-stun'
+import { once } from 'events'
 
 import { networkInterfaces } from 'os'
 
@@ -89,17 +90,19 @@ describe.only('check listening to sockets', function () {
   }
 
   async function stopListener(socket: Listener) {
-    await new Promise((resolve) => {
-      socket.once('close', resolve)
-      socket.close()
-    })
+    const promise = once(socket, 'close')
+
+    await socket.close()
+
+    return promise
   }
 
   async function waitUntilListening(socket: Listener, ma: Multiaddr) {
-    await new Promise((resolve) => {
-      socket.once('listening', resolve)
-      socket.listen(ma)
-    })
+    const promise = once(socket, 'listening')
+
+    await socket.listen(ma)
+
+    return promise
   }
 
   it('recreate the socket and perform STUN request', async function () {

--- a/src/listener.spec.ts
+++ b/src/listener.spec.ts
@@ -17,7 +17,7 @@ import { once } from 'events'
 import { networkInterfaces } from 'os'
 import { u8aEquals } from '@hoprnet/hopr-utils'
 
-describe.only('check listening to sockets', function () {
+describe('check listening to sockets', function () {
   /**
    * Encapsulates the logic that is necessary to lauch a test
    * STUN server instance and track whether it receives requests

--- a/src/listener.spec.ts
+++ b/src/listener.spec.ts
@@ -201,20 +201,17 @@ describe.only('check listening to sockets', function () {
       testMessage
     )
 
-    new Promise<void>((resolve) => {
-      const socket = net.createConnection(
-        {
-          host: '127.0.0.1',
-          port: node.listener.getPort()
-        },
-        () => {
-          socket.write(testMessage, () => {
-            socket.end()
-            resolve()
-          })
-        }
-      )
-    })
+    const socket = net.createConnection(
+      {
+        host: '127.0.0.1',
+        port: node.listener.getPort()
+      },
+      () => {
+        socket.write(testMessage, () => {
+          socket.end()
+        })
+      }
+    )
 
     await msgReceived.promise
 

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -435,7 +435,7 @@ class Listener extends EventEmitter implements InterfaceListener {
     }
 
     if (externalAddress == undefined) {
-      log(`STUN requests led to multiple ambigous results, hence node seems to be behind a bidirectional NAT.`)
+      log(`STUN requests led to multiple ambiguous results, hence node seems to be behind a bidirectional NAT.`)
       return
     }
 

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -509,7 +509,7 @@ class Listener extends EventEmitter implements InterfaceListener {
     const promises: Promise<ConnectResult>[] = []
     const abort = new AbortController()
 
-    for (const relay of randomSubset(this.relays, MAX_RELAYS_TO_CHECK)) {
+    for (const relay of randomSubset(this.relays, Math.min(MAX_RELAYS_TO_CHECK, this.relays.length))) {
       const relayPeerId = relay.getPeerId()
 
       if (relayPeerId == null || this.peerId.toB58String() === relayPeerId) {

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -604,7 +604,9 @@ class Listener extends EventEmitter implements InterfaceListener {
       conn = await this.upgrader.upgradeOutbound(maConn)
     } catch (err) {
       if (err.code === 'ERR_ENCRYPTION_FAILED') {
-        error(`outbound connection to potential relay node failed because encryption failed. Maybe connected to the wrong node?`)
+        error(
+          `outbound connection to potential relay node failed because encryption failed. Maybe connected to the wrong node?`
+        )
       } else {
         error('outbound connection to potential relay node failed.', err)
       }

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -99,6 +99,8 @@ class Listener extends EventEmitter implements InterfaceListener {
       // `udp6` does not seem to work in Node 12.x
       // can receive IPv6 packet and IPv4 after reconnecting the socket
       type: 'udp4',
+      // set to true to reuse port that is bound
+      // to TCP socket
       reuseAddr: true
     })
 
@@ -237,7 +239,11 @@ class Listener extends EventEmitter implements InterfaceListener {
    * @returns list of addresses under which the node is available
    */
   getAddrs(): Multiaddr[] {
-    return [...this.addrs.external, ...this.addrs.relays, ...this.addrs.interface].filter((addr) => addr)
+    return (
+      [...this.addrs.external, ...this.addrs.relays, ...this.addrs.interface]
+        // Filter empty entries
+        .filter((addr) => addr)
+    )
   }
 
   /**
@@ -343,13 +349,14 @@ class Listener extends EventEmitter implements InterfaceListener {
         this.udpSocket.removeListener('listening', resolve)
         reject(err)
       })
-      this.udpSocket.once('error', reject)
+
+      this.udpSocket.once('listening', () => {
+        this.udpSocket.removeListener('error', reject)
+        resolve()
+      })
 
       try {
-        this.udpSocket.bind(port, () => {
-          this.udpSocket.removeListener('error', reject)
-          resolve()
-        })
+        this.udpSocket.bind(port)
       } catch (err) {
         error(`Could not bind to UDP socket. ${err.message}`)
         reject(err)
@@ -369,13 +376,14 @@ class Listener extends EventEmitter implements InterfaceListener {
         this.tcpSocket.removeListener('listening', resolve)
         reject(err)
       })
-      this.tcpSocket.once('error', reject)
+
+      this.tcpSocket.once('listening', () => {
+        this.tcpSocket.removeListener('error', reject)
+        resolve()
+      })
 
       try {
-        this.tcpSocket.listen(opts, () => {
-          this.tcpSocket.removeListener('error', reject)
-          resolve()
-        })
+        this.tcpSocket.listen(opts)
       } catch (err) {
         error(`Could not bind to TCP socket. ${err.message}`)
         reject(err)
@@ -504,7 +512,7 @@ class Listener extends EventEmitter implements InterfaceListener {
       (iface: NetworkInterfaceInfo) => iface.family.toLowerCase() == family && !iface.internal
     )
 
-    if (usableInterfaces == undefined) {
+    if (usableInterfaces == undefined || usableInterfaces.length == 0) {
       throw Error(`Desired interface <${this._interface}> does not exist or does not have any external addresses.`)
     }
 
@@ -563,10 +571,10 @@ class Listener extends EventEmitter implements InterfaceListener {
 
     clearTimeout(timeout)
 
-    const filteredAndSortedResult = rawResults.filter((res) => res.latency >= 0).sort((a, b) => a.latency - b.latency)
+    const filteredAndSortedResults = rawResults.filter((res) => res.latency >= 0).sort((a, b) => a.latency - b.latency)
 
-    for (const res of filteredAndSortedResult.slice(0, MAX_RELAYS_PER_NODE)) {
-      this.addrs.relays.push(new Multiaddr(`/p2p/${res.id}/p2p-circuit/p2p/${this.peerId}`))
+    for (const result of filteredAndSortedResults.slice(0, MAX_RELAYS_PER_NODE)) {
+      this.addrs.relays.push(new Multiaddr(`/p2p/${result.id}/p2p-circuit/p2p/${this.peerId}`))
     }
   }
 
@@ -595,7 +603,11 @@ class Listener extends EventEmitter implements InterfaceListener {
     try {
       conn = await this.upgrader.upgradeOutbound(maConn)
     } catch (err) {
-      error(err)
+      if (err.code === 'ERR_ENCRYPTION_FAILED') {
+        error(`outbound connection to potential relay node failed. Maybe connected to the wrong node?`)
+      } else {
+        error('outbound connection to potential relay node failed.', err)
+      }
       if (conn != undefined) {
         try {
           await conn.close()

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -604,7 +604,7 @@ class Listener extends EventEmitter implements InterfaceListener {
       conn = await this.upgrader.upgradeOutbound(maConn)
     } catch (err) {
       if (err.code === 'ERR_ENCRYPTION_FAILED') {
-        error(`outbound connection to potential relay node failed. Maybe connected to the wrong node?`)
+        error(`outbound connection to potential relay node failed because encryption failed. Maybe connected to the wrong node?`)
       } else {
         error('outbound connection to potential relay node failed.', err)
       }

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -281,8 +281,6 @@ class Listener extends EventEmitter implements InterfaceListener {
       } else {
         this.__connections[index] = this.__connections.pop() as MultiaddrConnection
       }
-
-      console.log(`after`, this.__connections.length)
     }
 
     maConn.conn.once('close', untrackConn)

--- a/src/stun.ts
+++ b/src/stun.ts
@@ -69,7 +69,7 @@ export function handleStunRequest(socket: Socket, data: Buffer, rinfo: RemoteInf
 
 /**
  * Tries to determine the external IPv4 address
- * @returns Addrs+Port or undefined if the STUN response are ambigous (e.g. bidirectional NAT)
+ * @returns Addrs+Port or undefined if the STUN response are ambiguous (e.g. bidirectional NAT)
  *
  * @param multiAddrs Multiaddrs to use as STUN servers
  * @param socket Node.JS socket to use for the STUN request


### PR DESCRIPTION
### Startup

Current behavior:
- `getAddrs()` throws if `listen()` is not completed (== all potential relays got contacted))

New behavior:
- `getAddrs()` returns *after* binding to OS socket those addresses that are known. External address and relays addresses are added once known

Fixes #146 , #163 

### Relay selection

- Limit number of contacted relays and number chosen relays

### Announced addresses

- listener.getAddrs() does not return duplicates

### Connection tracking

- Fixes an error that prevents listener from tracking open connections correctly

### Unit testing

- massively simplified
- testing one specific behavior per test case

Referring to https://github.com/hoprnet/hoprnet/issues/1843