### PR TITLE
Dynamically remove relays - API change

### DIFF
--- a/src/base/listener.spec.ts
+++ b/src/base/listener.spec.ts
@@ -12,116 +12,155 @@ import net from 'net'
 import Defer from 'p-defer'
 import type { DeferredPromise } from 'p-defer'
 import * as stun from 'webrtc-stun'
-import { once, EventEmitter } from 'events'
+import { once, on, EventEmitter } from 'events'
 
 import { networkInterfaces } from 'os'
 import { u8aEquals } from '@hoprnet/hopr-utils'
 import { PublicNodesEmitter } from '../types'
 
-describe('check listening to sockets', function () {
-  /**
-   * Encapsulates the logic that is necessary to lauch a test
-   * STUN server instance and track whether it receives requests
-   * @param port port to listen to
-   * @param state used to track incoming messages
-   */
-  async function startStunServer(
-    port: number | undefined,
-    state: { msgReceived: DeferredPromise<void> }
-  ): Promise<Socket> {
-    const socket = dgram.createSocket('udp4')
+/**
+ * Decorated Listener class that throws events after
+ * updating list of potential relays
+ */
+class TestingListener extends Listener {
+  public emitter: EventEmitter
+  constructor(...args: ConstructorParameters<typeof Listener>) {
+    super(...args)
 
-    await new Promise<void>((resolve, reject) => {
-      socket.once('error', (err: any) => {
-        socket.removeListener('listening', resolve)
-        reject(err)
-      })
-      socket.once('listening', () => {
-        socket.removeListener('error', reject)
-        resolve()
-      })
-
-      try {
-        socket.bind(port)
-      } catch (err) {
-        reject(err)
-      }
-    })
-
-    socket.on('message', (msg: Buffer, rinfo: RemoteInfo) => {
-      state.msgReceived.resolve()
-      handleStunRequest(socket, msg, rinfo)
-    })
-
-    return socket
+    this.emitter = new EventEmitter()
   }
 
-  async function waitUntilListening(socket: Listener, ma: Multiaddr) {
-    const promise = once(socket, 'listening')
+  protected onRemoveRelay(...args: Parameters<Listener['onRemoveRelay']>) {
+    super.onRemoveRelay(...args)
 
-    await socket.listen(ma)
-
-    return promise
+    this.emitter.emit(`_nodeOffline`, ...args)
   }
 
-  /**
-   * Creates a node and attaches message listener to it.
-   * @param publicNodes emitter that emit an event on new public nodes
-   * @param initialNodes nodes that are initially known
-   * @param state check message reception and content of message
-   * @param expectedMessage message to check for, or undefined to skip this check
-   * @param peerId peerId of the node
-   * @returns
-   */
-  async function startNode(
-    initialNodes: Multiaddr[],
-    state: { msgReceived: DeferredPromise<void>; expectedMessageReceived?: DeferredPromise<void> },
-    expectedMessage?: Uint8Array,
-    peerId?: PeerId
-  ) {
-    peerId = peerId ?? (await PeerId.create({ keyType: 'secp256k1' }))
-    const publicNodesEmitter = new EventEmitter() as PublicNodesEmitter
+  protected async updatePublicNodes(...args: Parameters<Listener['updatePublicNodes']>) {
+    await super.updatePublicNodes(...args)
 
-    const listener = new Listener(
-      undefined,
-      {
-        upgradeInbound: async (conn: MultiaddrConnection) => {
-          if (expectedMessage != undefined) {
-            for await (const msg of conn.source) {
-              if (u8aEquals(msg.slice(), expectedMessage)) {
-                state.expectedMessageReceived?.resolve()
-              }
+    this.emitter.emit(`_newNodeRegistered`, ...args)
+  }
+}
+
+/**
+ * Encapsulates the logic that is necessary to lauch a test
+ * STUN server instance and track whether it receives requests
+ * @param port port to listen to
+ * @param state used to track incoming messages
+ */
+async function startStunServer(
+  port: number | undefined,
+  state: { msgReceived: DeferredPromise<void> }
+): Promise<Socket> {
+  const socket = dgram.createSocket('udp4')
+
+  await new Promise<void>((resolve, reject) => {
+    socket.once('error', (err: any) => {
+      socket.removeListener('listening', resolve)
+      reject(err)
+    })
+    socket.once('listening', () => {
+      socket.removeListener('error', reject)
+      resolve()
+    })
+
+    try {
+      socket.bind(port)
+    } catch (err) {
+      reject(err)
+    }
+  })
+
+  socket.on('message', (msg: Buffer, rinfo: RemoteInfo) => {
+    state.msgReceived.resolve()
+    handleStunRequest(socket, msg, rinfo)
+  })
+
+  return socket
+}
+
+async function waitUntilListening(socket: Listener, ma: Multiaddr) {
+  const promise = once(socket, 'listening')
+
+  await socket.listen(ma)
+
+  return promise
+}
+
+/**
+ * Creates a node and attaches message listener to it.
+ * @param publicNodes emitter that emit an event on new public nodes
+ * @param initialNodes nodes that are initially known
+ * @param state check message reception and content of message
+ * @param expectedMessage message to check for, or undefined to skip this check
+ * @param peerId peerId of the node
+ * @returns
+ */
+async function startNode(
+  initialNodes: Multiaddr[],
+  state: { msgReceived: DeferredPromise<void>; expectedMessageReceived?: DeferredPromise<void> },
+  expectedMessage?: Uint8Array,
+  peerId?: PeerId
+) {
+  peerId = peerId ?? (await PeerId.create({ keyType: 'secp256k1' }))
+  const publicNodesEmitter = new EventEmitter() as PublicNodesEmitter
+
+  const listener = new TestingListener(
+    undefined,
+    {
+      upgradeInbound: async (conn: MultiaddrConnection) => {
+        if (expectedMessage != undefined) {
+          for await (const msg of conn.source) {
+            if (u8aEquals(msg.slice(), expectedMessage)) {
+              state.expectedMessageReceived?.resolve()
             }
           }
+        }
 
-          state.msgReceived.resolve()
-          return conn
-        },
-        upgradeOutbound: async (conn: MultiaddrConnection) => conn
-      } as unknown as Upgrader,
-      publicNodesEmitter,
-      initialNodes,
-      peerId,
-      undefined
-    )
+        state.msgReceived.resolve()
+        return conn
+      },
+      upgradeOutbound: async (conn: MultiaddrConnection) => conn
+    } as unknown as Upgrader,
+    publicNodesEmitter,
+    initialNodes,
+    peerId,
+    undefined
+  )
 
-    await waitUntilListening(listener, new Multiaddr(`/ip4/127.0.0.1/tcp/0/p2p/${peerId.toB58String()}`))
+  await waitUntilListening(listener, new Multiaddr(`/ip4/127.0.0.1/tcp/0/p2p/${peerId.toB58String()}`))
 
-    return {
-      peerId,
-      listener,
-      publicNodesEmitter
+  const initialNodesRegistered: Multiaddr[] = []
+
+  for await (const initialNode of on(listener.emitter, '_newNodeRegistered')) {
+    if (initialNodesRegistered.push(initialNode[0]) == initialNodes.length) {
+      break
     }
   }
 
-  async function stopNode(socket: Socket | Listener) {
-    const closePromise = once(socket, 'close')
+  assert(
+    initialNodes.every((ma: Multiaddr) =>
+      initialNodesRegistered.some((registeredMa: Multiaddr) => registeredMa.toString() === ma.toString())
+    )
+  )
 
-    socket.close()
-
-    return closePromise
+  return {
+    peerId,
+    listener,
+    publicNodesEmitter
   }
+}
 
+async function stopNode(socket: Socket | Listener) {
+  const closePromise = once(socket, 'close')
+
+  socket.close()
+
+  return closePromise
+}
+
+describe('check listening to sockets', function () {
   it('recreate the socket and perform STUN request', async function () {
     let listener: Listener
     const peerId = await PeerId.create({ keyType: 'secp256k1' })
@@ -165,7 +204,7 @@ describe('check listening to sockets', function () {
 
     const node = await startNode([stunServerMultiaddr], { msgReceived: Defer() })
 
-    const eventPromise = once(node.listener, '_newNodeRegistered')
+    const eventPromise = once(node.listener.emitter, '_newNodeRegistered')
 
     node.publicNodesEmitter.emit(
       `addPublicNode`,
@@ -304,7 +343,7 @@ describe('check listening to sockets', function () {
       msgReceived: Defer()
     })
 
-    let eventPromise = once(node.listener, '_newNodeRegistered')
+    let eventPromise = once(node.listener.emitter, '_newNodeRegistered')
     node.publicNodesEmitter.emit(
       'addPublicNode',
       new Multiaddr(`/ip4/127.0.0.1/tcp/${relay.listener.getPort()}/p2p/${relay.peerId.toB58String()}`)
@@ -312,7 +351,7 @@ describe('check listening to sockets', function () {
 
     await eventPromise
 
-    eventPromise = once(node.listener, '_newNodeRegistered')
+    eventPromise = once(node.listener.emitter, '_newNodeRegistered')
     node.publicNodesEmitter.emit(
       'addPublicNode',
       new Multiaddr(`/ip4/127.0.0.1/tcp/${relay.listener.getPort()}/p2p/${relay.peerId.toB58String()}`)
@@ -402,7 +441,7 @@ describe('check listening to sockets', function () {
       msgReceived: Defer()
     })
 
-    let eventPromise = once(node.listener, '_newNodeRegistered')
+    let eventPromise = once(node.listener.emitter, '_newNodeRegistered')
     node.publicNodesEmitter.emit(
       `addPublicNode`,
       new Multiaddr(`/ip4/127.0.0.1/tcp/${relay.listener.getPort()}/p2p/${relay.peerId.toB58String()}`)
@@ -414,7 +453,7 @@ describe('check listening to sockets', function () {
 
     assert(addrs.includes(`/p2p/${relay.peerId.toB58String()}/p2p-circuit/p2p/${node.peerId.toB58String()}`))
 
-    eventPromise = once(node.listener, '_newNodeRegistered')
+    eventPromise = once(node.listener.emitter, '_newNodeRegistered')
     node.publicNodesEmitter.emit(
       `addPublicNode`,
       new Multiaddr(`/ip4/127.0.0.1/tcp/${relay.listener.getPort()}/p2p/${relay.peerId}`)
@@ -444,7 +483,7 @@ describe('check listening to sockets', function () {
       msgReceived: Defer()
     })
 
-    let eventPromise = once(node.listener, '_newNodeRegistered')
+    let eventPromise = once(node.listener.emitter, '_newNodeRegistered')
     node.publicNodesEmitter.emit(
       `addPublicNode`,
       new Multiaddr(`/ip4/127.0.0.1/tcp/${relay.listener.getPort()}/p2p/${relay.peerId.toB58String()}`)
@@ -461,7 +500,7 @@ describe('check listening to sockets', function () {
       new Multiaddr(`/ip4/127.0.0.1/tcp/${relay.listener.getPort()}/p2p/${relay.peerId}`)
     )
 
-    eventPromise = once(node.listener, '_newNodeRegistered')
+    eventPromise = once(node.listener.emitter, '_newNodeRegistered')
     node.publicNodesEmitter.emit(
       `addPublicNode`,
       new Multiaddr(`/ip4/127.0.0.1/tcp/${relay.listener.getPort()}/p2p/${relay.peerId.toB58String()}`)
@@ -481,7 +520,7 @@ describe('check listening to sockets', function () {
       relay.peerId
     )
 
-    eventPromise = once(node.listener, '_newNodeRegistered')
+    eventPromise = once(node.listener.emitter, '_newNodeRegistered')
     node.publicNodesEmitter.emit(
       `addPublicNode`,
       new Multiaddr(`/ip4/127.0.0.1/tcp/${newRelay.listener.getPort()}/p2p/${relay.peerId.toB58String()}`)

--- a/src/base/listener.spec.ts
+++ b/src/base/listener.spec.ts
@@ -452,7 +452,10 @@ describe('check listening to sockets', function () {
 
     let addrs = node.listener.getAddrs().map((ma: Multiaddr) => ma.toString())
 
-    assert(addrs.includes(`/p2p/${relay.peerId.toB58String()}/p2p-circuit/p2p/${node.peerId.toB58String()}`))
+    assert(
+      addrs.includes(`/p2p/${relay.peerId.toB58String()}/p2p-circuit/p2p/${node.peerId.toB58String()}`),
+      'Addrs should include new relay node'
+    )
 
     eventPromise = once(node.listener.emitter, '_newNodeRegistered')
     node.publicNodesEmitter.emit(
@@ -467,7 +470,8 @@ describe('check listening to sockets', function () {
     assert(addrs.length == addrsAfterSecondEvent.length)
 
     assert(
-      addrsAfterSecondEvent.includes(`/p2p/${relay.peerId.toB58String()}/p2p-circuit/p2p/${node.peerId.toB58String()}`)
+      addrsAfterSecondEvent.includes(`/p2p/${relay.peerId.toB58String()}/p2p-circuit/p2p/${node.peerId.toB58String()}`),
+      'Addrs should include new relay node'
     )
 
     await Promise.all([stopNode(node.listener), stopNode(relay.listener), stopNode(stunServer)])
@@ -568,9 +572,10 @@ describe('check listening to sockets', function () {
 
     let addrsAfterRemoval = node.listener.getAddrs().map((ma: Multiaddr) => ma.toString())
 
+    assert(addrs.length - 1 == addrsAfterRemoval.length, 'Addr should be removed, hence size should be reduced by one.')
     assert(
-      addrs.length - 1 == addrsAfterRemoval.length &&
-        !addrsAfterRemoval.includes(`/p2p/${relay.peerId.toB58String()}/p2p-circuit/p2p/${node.peerId.toB58String()}`)
+      !addrsAfterRemoval.includes(`/p2p/${relay.peerId.toB58String()}/p2p-circuit/p2p/${node.peerId.toB58String()}`),
+      'Addrs should not contain removed node'
     )
 
     await Promise.all([stopNode(node.listener), stopNode(relay.listener), stopNode(stunServer)])
@@ -601,11 +606,16 @@ describe('check listening to sockets', function () {
     let addrsAfterRemoval = node.listener.getAddrs().map((ma: Multiaddr) => ma.toString())
 
     assert(
-      addrs.length == addrsAfterRemoval.length &&
-        !addrsAfterRemoval.includes(
-          `/p2p/${relay.peerId.toB58String()}/p2p-circuit/p2p/${node.peerId.toB58String()}`
-        ) &&
-        addrs.every((addr: string) => addrsAfterRemoval.some((addrAfterRemoval: string) => addr === addrAfterRemoval))
+      addrs.length == addrsAfterRemoval.length,
+      'Number of addresses should stay same after removing invalid multiaddr'
+    )
+    assert(
+      !addrsAfterRemoval.includes(`/p2p/${relay.peerId.toB58String()}/p2p-circuit/p2p/${node.peerId.toB58String()}`),
+      'Addrs should not include addr of invalid node'
+    )
+    assert(
+      addrs.every((addr: string) => addrsAfterRemoval.some((addrAfterRemoval: string) => addr === addrAfterRemoval)),
+      'Addrs should stay same after trying remove invalid multiaddr'
     )
 
     await Promise.all([stopNode(node.listener), stopNode(relay.listener), stopNode(stunServer)])

--- a/src/base/listener.spec.ts
+++ b/src/base/listener.spec.ts
@@ -19,7 +19,7 @@ import { u8aEquals } from '@hoprnet/hopr-utils'
 import { PublicNodesEmitter } from '../types'
 
 /**
- * Decorated Listener class that throws events after
+ * Decorated Listener class that emits events after
  * updating list of potential relays
  */
 class TestingListener extends Listener {

--- a/src/base/listener.spec.ts
+++ b/src/base/listener.spec.ts
@@ -572,10 +572,7 @@ describe('check listening to sockets', function () {
 
     eventPromise = once(node.listener.emitter, '_nodeOffline')
 
-    node.publicNodesEmitter.emit(
-      `removePublicNode`,
-      new Multiaddr(`/ip4/127.0.0.1/tcp/${relay.listener.getPort()}/p2p/${relay.peerId.toB58String()}`)
-    )
+    node.publicNodesEmitter.emit(`removePublicNode`, relay.peerId)
 
     await eventPromise
 
@@ -605,10 +602,7 @@ describe('check listening to sockets', function () {
 
     let eventPromise = once(node.listener.emitter, '_nodeOffline')
 
-    node.publicNodesEmitter.emit(
-      `removePublicNode`,
-      new Multiaddr(`/ip4/127.0.0.1/tcp/${relay.listener.getPort()}/p2p/${relay.peerId.toB58String()}`)
-    )
+    node.publicNodesEmitter.emit(`removePublicNode`, relay.peerId)
 
     await eventPromise
 

--- a/src/base/listener.ts
+++ b/src/base/listener.ts
@@ -212,10 +212,7 @@ class Listener extends EventEmitter implements InterfaceListener {
    * @param ma Multiaddr of node that is considered to be offline now
    */
   protected onRemoveRelay(ma: Multiaddr) {
-    const maPeerId = ma.getPeerId()
-    const tuples = ma.tuples()
-
-    if (maPeerId == null || !isUsableRelay(ma, this.peerId)) {
+    if (ma.getPeerId() == null || !isUsableRelay(ma, this.peerId)) {
       return
     }
 

--- a/src/base/listener.ts
+++ b/src/base/listener.ts
@@ -211,19 +211,15 @@ class Listener extends EventEmitter implements InterfaceListener {
    * Called once a node is considered to be offline
    * @param ma Multiaddr of node that is considered to be offline now
    */
-  protected onRemoveRelay(ma: Multiaddr) {
-    if (ma.getPeerId() == null || !isUsableRelay(ma, this.peerId)) {
-      return
-    }
-
-    this.publicNodes = removeNodeFromList(this.publicNodes, ma)
+  protected onRemoveRelay(peer: PeerId) {
+    this.publicNodes = this.publicNodes.filter((entry: NodeEntry) => entry.peerId !== peer.toB58String())
 
     this.addrs.relays = this.publicNodes.map(
       (entry: NodeEntry) => new Multiaddr(`/p2p/${entry.peerId}/p2p-circuit/p2p/${this.peerId}`)
     )
 
     log(
-      `relay ${ma.toString()} ${red(`removed`)}. Current addrs:\n\t${this.addrs.relays
+      `relay ${peer.toB58String()} ${red(`removed`)}. Current addrs:\n\t${this.addrs.relays
         .map((addr: Multiaddr) => addr.toString())
         .join(`\n\t`)}`
     )

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 type Multiaddr = import('multiaddr').Multiaddr
+type PeerId = import('peer-id')
 
 type Suffix = 'PublicNode'
 type AddEventName = `add${Suffix}`
@@ -7,36 +8,36 @@ type RemoveEventName = `remove${Suffix}`
 export interface PublicNodesEmitter {
   addListener(event: AddEventName | RemoveEventName, listener: () => void): this
   addListener(event: AddEventName, listener: (newNode: Multiaddr) => void): this
-  addListener(event: RemoveEventName, listener: (removeNode: Multiaddr) => void): this
+  addListener(event: RemoveEventName, listener: (removeNode: PeerId) => void): this
   addListener(event: string | symbol, listener: (...args: any[]) => void): this
 
   emit(event: AddEventName | RemoveEventName): boolean
   emit(event: AddEventName, newNode: Multiaddr): boolean
-  emit(event: RemoveEventName, removeNode: Multiaddr): boolean
+  emit(event: RemoveEventName, removeNode: PeerId): boolean
   emit(event: string | symbol, ...args: any[]): boolean
 
   on(event: AddEventName | RemoveEventName, listener: () => void): this
   on(event: AddEventName, listener: (newNode: Multiaddr) => void): this
-  on(event: RemoveEventName, listener: (removeNode: Multiaddr) => void): this
+  on(event: RemoveEventName, listener: (removeNode: PeerId) => void): this
   on(event: string | symbol, listener: (...args: any[]) => void): this
 
   once(event: AddEventName | RemoveEventName, listener: () => void): this
   once(event: AddEventName, listener: (newNode: Multiaddr) => void): this
-  once(event: RemoveEventName, listener: (removeNode: Multiaddr) => void): this
+  once(event: RemoveEventName, listener: (removeNode: PeerId) => void): this
   once(event: string | symbol, listener: (...args: any[]) => void): this
 
   prependListener(event: AddEventName | RemoveEventName, listener: () => void): this
   prependListener(event: AddEventName, listener: (newNode: Multiaddr) => void): this
-  prependListener(event: RemoveEventName, listener: (removeNode: Multiaddr) => void): this
+  prependListener(event: RemoveEventName, listener: (removeNode: PeerId) => void): this
   prependListener(event: string | symbol, listener: (...args: any[]) => void): this
 
   prependOnceListener(event: AddEventName | RemoveEventName, listener: () => void): this
   prependOnceListener(event: AddEventName, listener: (newNode: Multiaddr) => void): this
-  prependOnceListener(event: RemoveEventName, listener: (removeNode: Multiaddr) => void): this
+  prependOnceListener(event: RemoveEventName, listener: (removeNode: PeerId) => void): this
   prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this
 
   removeListener(event: AddEventName | RemoveEventName, listener: () => void): this
   removeListener(event: AddEventName, listener: (newNode: Multiaddr) => void): this
-  removeListener(event: RemoveEventName, listener: (removeNode: Multiaddr) => void): this
+  removeListener(event: RemoveEventName, listener: (removeNode: PeerId) => void): this
   removeListener(event: string | symbol, listener: (...args: any[]) => void): this
 }

--- a/src/webrtc/upgrader.spec.ts
+++ b/src/webrtc/upgrader.spec.ts
@@ -107,7 +107,7 @@ describe('webrtc upgrader', function () {
     assert(webRTCUpgrader.rtcConfig?.iceServers == undefined)
   })
 
-  it(`limit available STUN servers`, async function () {
+  it('limit available STUN servers', async function () {
     const publicNodeEmitter = new EventEmitter() as PublicNodesEmitter
 
     const webRTCUpgrader = new WebRTCUpgrader(publicNodeEmitter)
@@ -126,5 +126,46 @@ describe('webrtc upgrader', function () {
     }
 
     assert(webRTCUpgrader.rtcConfig?.iceServers?.length == MAX_STUN_SERVERS)
+  })
+
+  it('remove offline STUN servers', async function () {
+    const publicNodeEmitter = new EventEmitter() as PublicNodesEmitter
+
+    const webRTCUpgrader = new WebRTCUpgrader(publicNodeEmitter)
+
+    const ATTEMPTS = Math.min(MAX_STUN_SERVERS, 3)
+
+    const multiaddrs: Multiaddr[] = []
+    for (let i = 0; i < ATTEMPTS; i++) {
+      const multiaddr = new Multiaddr(`/ip4/1.2.3.4/udp/${i}`)
+      multiaddrs.push(multiaddr)
+
+      publicNodeEmitter.emit(`addPublicNode`, multiaddr)
+
+      assert(
+        webRTCUpgrader.rtcConfig?.iceServers?.length == i + 1 &&
+          webRTCUpgrader.rtcConfig.iceServers[0].urls === multiaddrToIceServer(multiaddr)
+      )
+    }
+
+    for (let i = 0; i < ATTEMPTS; i++) {
+      publicNodeEmitter.emit(`removePublicNode`, multiaddrs[i])
+
+      assert((webRTCUpgrader.rtcConfig?.iceServers?.length as any) == ATTEMPTS - i - 1)
+    }
+
+    assert((webRTCUpgrader.rtcConfig?.iceServers?.length as any) == 0)
+  })
+
+  it('remove offline STUN servers - edge cases', async function () {
+    const publicNodeEmitter = new EventEmitter() as PublicNodesEmitter
+
+    const webRTCUpgrader = new WebRTCUpgrader(publicNodeEmitter)
+
+    const multiaddr = new Multiaddr(`/ip4/1.2.3.4/udp/123`)
+
+    publicNodeEmitter.emit(`removePublicNode`, multiaddr)
+
+    assert((webRTCUpgrader.rtcConfig?.iceServers?.length as any) == undefined)
   })
 })


### PR DESCRIPTION
Change signature of removal event:

- emit PeerId of removed node instead of their Multiaddr