### PR TITLE
flow logging

### DIFF
--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -271,7 +271,7 @@ cat "${bob_log}" | sed -En 's/hopr-connect.*FLOW: /bob: /p' >> "${flow_log}"
 cat "${charly_log}" | sed -En 's/hopr-connect.*FLOW: /charly: /p' >> "${flow_log}"
 cat "${dave_log}" | sed -En 's/hopr-connect.*FLOW: /dave: /p' >> "${flow_log}"
 cat "${ed_log}" | sed -En 's/hopr-connect.*FLOW: /ed: /p' >> "${flow_log}"
-sort -o "${flow_log}" "${flow_log}"
+sort -k1,1 --stable --output "${flow_log}" "${flow_log}"
 
 expect_file_content "${alice_pipe}" \
 ">bob: test from alice

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -266,13 +266,12 @@ wait_for_regex_in_file "${dave_log}" "dialProtocol to bob failed"
 
 # create global flow log
 rm -Rf "${flow_log}"
-cat "/var/tmp/hopr-connect-alice.log" | grep "FLOW: " | sed -En 's/hopr-connect.*FLOW: /alice: /p' >> "${flow_log}"
-cat "/var/tmp/hopr-connect-bob.log" | grep "FLOW: " | sed -En 's/hopr-connect.*FLOW: /bob: /p' >> "${flow_log}"
-cat "/var/tmp/hopr-connect-charly.log" | grep "FLOW: " | sed -En 's/hopr-connect.*FLOW: /charly: /p' >> "${flow_log}"
-cat "/var/tmp/hopr-connect-dave.log" | grep "FLOW: " | sed -En 's/hopr-connect.*FLOW: /dave: /p' >> "${flow_log}"
-cat "/var/tmp/hopr-connect-ed.log" | grep "FLOW: " | sed -En 's/hopr-connect.*FLOW: /ed: /p' >> "${flow_log}"
-
-sort "${flow_log}" > "${flow_log}"
+cat "${alice_log}" | sed -En 's/hopr-connect.*FLOW: /alice: /p' >> "${flow_log}"
+cat "${bob_log}" | sed -En 's/hopr-connect.*FLOW: /bob: /p' >> "${flow_log}"
+cat "${charly_log}" | sed -En 's/hopr-connect.*FLOW: /charly: /p' >> "${flow_log}"
+cat "${dave_log}" | sed -En 's/hopr-connect.*FLOW: /dave: /p' >> "${flow_log}"
+cat "${ed_log}" | sed -En 's/hopr-connect.*FLOW: /ed: /p' >> "${flow_log}"
+sort -o "${flow_log}" "${flow_log}"
 
 expect_file_content "${alice_pipe}" \
 ">bob: test from alice

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -25,6 +25,9 @@ declare tmp="/tmp"
 [[ -d "${tmp}" && -h "${tmp}" ]] && tmp="/var/tmp"
 [[ -d "${tmp}" && -h "${tmp}" ]] && { msg "Neither /tmp or /var/tmp can be used for writing logs"; exit 1; }
 
+
+declare flow_log="${tmp}/hopr-connect-flow.log"
+
 declare alice_log="${tmp}/hopr-connect-alice.log"
 declare alice_pipe="${tmp}/hopr-connect-alice-pipe.log"
 declare alice_port=11090
@@ -125,6 +128,7 @@ log "bob msgs -> ${bob_pipe}"
 log "charly logs -> ${charly_log}"
 log "dave logs -> ${dave_log}"
 log "ed logs -> ${ed_log}"
+log "common flow log -> ${flow_log}"
 
 # run alice (client)
 # should be able to send 'test from alice' to bob through relay charly
@@ -259,6 +263,16 @@ wait_for_regex_in_file "${ed_log}" "all tasks executed"
 # dave should have failed to complete
 wait_for_regex_in_file "${dave_log}" "Answer was: <FAIL_RELAY_FULL>"
 wait_for_regex_in_file "${dave_log}" "dialProtocol to bob failed"
+
+# create global flow log
+rm -Rf "${flow_log}"
+cat "/var/tmp/hopr-connect-alice.log" | grep "FLOW: " | sed -En 's/hopr-connect.*FLOW: /alice: /p' >> "${flow_log}"
+cat "/var/tmp/hopr-connect-bob.log" | grep "FLOW: " | sed -En 's/hopr-connect.*FLOW: /bob: /p' >> "${flow_log}"
+cat "/var/tmp/hopr-connect-charly.log" | grep "FLOW: " | sed -En 's/hopr-connect.*FLOW: /charly: /p' >> "${flow_log}"
+cat "/var/tmp/hopr-connect-dave.log" | grep "FLOW: " | sed -En 's/hopr-connect.*FLOW: /dave: /p' >> "${flow_log}"
+cat "/var/tmp/hopr-connect-ed.log" | grep "FLOW: " | sed -En 's/hopr-connect.*FLOW: /ed: /p' >> "${flow_log}"
+
+sort "${flow_log}" > "${flow_log}"
 
 expect_file_content "${alice_pipe}" \
 ">bob: test from alice

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -270,7 +270,6 @@ cat "${alice_log}" | sed -En 's/hopr-connect.*FLOW: /alice: /p' >> "${flow_log}"
 cat "${bob_log}" | sed -En 's/hopr-connect.*FLOW: /bob: /p' >> "${flow_log}"
 cat "${charly_log}" | sed -En 's/hopr-connect.*FLOW: /charly: /p' >> "${flow_log}"
 cat "${dave_log}" | sed -En 's/hopr-connect.*FLOW: /dave: /p' >> "${flow_log}"
-cat "${ed_log}" | sed -En 's/hopr-connect.*FLOW: /ed: /p' >> "${flow_log}"
 sort -k1,1 --stable --output "${flow_log}" "${flow_log}"
 
 expect_file_content "${alice_pipe}" \

--- a/src/relay/connection.ts
+++ b/src/relay/connection.ts
@@ -372,6 +372,8 @@ class RelayConnection extends EventEmitter implements MultiaddrConnection {
 
       result = undefined
       streamPromise = (currentSource as Stream['source']).next()
+      
+      this.verbose(`FLOW: loop end`)
 
       yield Uint8Array.from([RelayPrefix.PAYLOAD, ...received.value.slice()])
     }

--- a/src/relay/connection.ts
+++ b/src/relay/connection.ts
@@ -299,10 +299,13 @@ class RelayConnection extends EventEmitter implements MultiaddrConnection {
       // 3. Handle source attach
       // 4. Handle status messages
       // 5. Handle payload messages
+      this.verbose(`FLOW: awaiting promises`)
       result = await Promise.race(promises)
+      this.verbose(`FLOW: promises resolved`)
 
       // Stream is done, nothing to do
       if (this._streamClosed && this.destroyed) {
+        this.verbose(`FLOW: stream is closed, break`)
         break
       }
 
@@ -319,6 +322,7 @@ class RelayConnection extends EventEmitter implements MultiaddrConnection {
         currentSource = undefined
         streamPromise = undefined
         this._migrationDone?.resolve()
+        this.verbose(`FLOW: stream switched, continue`)
         continue
       }
 
@@ -330,6 +334,7 @@ class RelayConnection extends EventEmitter implements MultiaddrConnection {
 
         streamPromise = undefined
         result = undefined
+        this.verbose(`FLOW: source attached, forwarding`)
         continue
       }
 
@@ -341,10 +346,12 @@ class RelayConnection extends EventEmitter implements MultiaddrConnection {
           this.destroyed = true
           this._destroyedPromise.resolve()
 
+          this.verbose(`FLOW: STOP received, break`)
           yield statusMsg
           break
         }
 
+        this.verbose(`FLOW: unrelated status message received, continue`)
         yield statusMsg
 
         continue
@@ -359,6 +366,7 @@ class RelayConnection extends EventEmitter implements MultiaddrConnection {
       if (received.done) {
         currentSource = undefined
         streamPromise = undefined
+        this.verbose(`FLOW: received.done == true, break`)
         break
       }
 
@@ -367,6 +375,7 @@ class RelayConnection extends EventEmitter implements MultiaddrConnection {
 
       yield Uint8Array.from([RelayPrefix.PAYLOAD, ...received.value.slice()])
     }
+    this.verbose(`FLOW: breaked out the loop`)
   }
 
   /**

--- a/src/relay/connection.ts
+++ b/src/relay/connection.ts
@@ -186,8 +186,8 @@ class RelayConnection extends EventEmitter implements MultiaddrConnection {
 
     this.verbose(`FLOW: setting closed`)
     this.setClosed()
-    
-    this.verbose(`FLOW: awaiting destroyed promise / timeout`)    
+
+    this.verbose(`FLOW: awaiting destroyed promise / timeout`)
     // @TODO remove timeout once issue with destroyPromise is solved
     await Promise.race([new Promise((resolve) => setTimeout(resolve, 100)), this._destroyedPromise.promise])
     this.verbose(`FLOW: close complete, finish`)
@@ -280,33 +280,35 @@ class RelayConnection extends EventEmitter implements MultiaddrConnection {
 
     while (true) {
       let promises: Promise<SinkType>[] = []
-      
-      let resolvedPromiseName 
+
+      let resolvedPromiseName
 
       const pushPromise = (promise: Promise<SinkType>, name: string) => {
-        promises.push(promise.then(res => { 
-          resolvedPromiseName = name
-          return res
-        }))
+        promises.push(
+          promise.then((res) => {
+            resolvedPromiseName = name
+            return res
+          })
+        )
       }
 
       // Wait for stream close and stream switch signals
-      pushPromise(this._closePromise.promise, "close")
-      pushPromise(this._sinkSwitchPromise.promise, "sinkSwitch")
+      pushPromise(this._closePromise.promise, 'close')
+      pushPromise(this._sinkSwitchPromise.promise, 'sinkSwitch')
 
       // Wait for source being attached to sink
       if (currentSource == undefined) {
-        pushPromise(this._sinkSourceAttachedPromise.promise, "sinkSourceAttached")
+        pushPromise(this._sinkSourceAttachedPromise.promise, 'sinkSourceAttached')
       }
 
       // Wait for status messages
-      pushPromise(this._statusMessagePromise.promise, "statusMessage")
+      pushPromise(this._statusMessagePromise.promise, 'statusMessage')
 
       // Wait for payload messages
       if (currentSource != undefined) {
         streamPromise = streamPromise ?? currentSource.next()
 
-        pushPromise(streamPromise, "payload")
+        pushPromise(streamPromise, 'payload')
       }
 
       // 1. Handle stream close
@@ -315,7 +317,7 @@ class RelayConnection extends EventEmitter implements MultiaddrConnection {
       // 4. Handle status messages
       // 5. Handle payload messages
       this.verbose(`FLOW: outgoing: awaiting promises`)
-      result = await Promise.race(promises)      
+      result = await Promise.race(promises)
       this.verbose(`FLOW: outgoing: promise ${resolvedPromiseName} resolved`)
 
       // Stream is done, nothing to do
@@ -387,7 +389,7 @@ class RelayConnection extends EventEmitter implements MultiaddrConnection {
 
       result = undefined
       streamPromise = (currentSource as Stream['source']).next()
-      
+
       this.verbose(`FLOW: loop end`)
 
       yield Uint8Array.from([RelayPrefix.PAYLOAD, ...received.value.slice()])
@@ -428,21 +430,23 @@ class RelayConnection extends EventEmitter implements MultiaddrConnection {
         let resolvedPromiseName
 
         const pushPromise = (promise: Promise<any>, name: string) => {
-          promises.push(promise.then(res => { 
-            resolvedPromiseName = name
-            return res
-          }))
+          promises.push(
+            promise.then((res) => {
+              resolvedPromiseName = name
+              return res
+            })
+          )
         }
         // Wait for stream close attempts
-        pushPromise(this._closePromise.promise, "close")
+        pushPromise(this._closePromise.promise, 'close')
 
         // Wait for stream switches
         if (!this._sourceSwitched) {
-          pushPromise(this._sourceSwitchPromise.promise, "sourceSwitch")          
+          pushPromise(this._sourceSwitchPromise.promise, 'sourceSwitch')
         }
 
         // Wait for payload messages
-        pushPromise(streamPromise, "payload")
+        pushPromise(streamPromise, 'payload')
 
         result = (await Promise.race(promises)) as any
 

--- a/src/relay/connection.ts
+++ b/src/relay/connection.ts
@@ -176,16 +176,21 @@ class RelayConnection extends EventEmitter implements MultiaddrConnection {
       this.verbose(`close called. No error`)
     }
 
+    this.verbose(`FLOW: queueing STOP`)
+    this.queueStatusMessage(Uint8Array.of(RelayPrefix.CONNECTION_STATUS, ConnectionStatusMessages.STOP))
+
     if (this.destroyed) {
+      this.verbose(`FLOW: connection already destroyed, finish`)
       return
     }
 
-    this.queueStatusMessage(Uint8Array.of(RelayPrefix.CONNECTION_STATUS, ConnectionStatusMessages.STOP))
-
+    this.verbose(`FLOW: setting closed`)
     this.setClosed()
-
+    
+    this.verbose(`FLOW: awaiting destroyed promise / timeout`)    
     // @TODO remove timeout once issue with destroyPromise is solved
     await Promise.race([new Promise((resolve) => setTimeout(resolve, 100)), this._destroyedPromise.promise])
+    this.verbose(`FLOW: close complete, finish`)
   }
 
   /**

--- a/src/relay/connection.ts
+++ b/src/relay/connection.ts
@@ -422,12 +422,8 @@ class RelayConnection extends EventEmitter implements MultiaddrConnection {
       }
 
       while (this._iteration == drainIteration) {
-<<<<<<< HEAD
-        const promises = []
-=======
         this.verbose(`FLOW: incoming: new loop iteration`)
         const promises: Promise<any>[] = []
->>>>>>> c9b4f8d (more logging of flow)
 
         let resolvedPromiseName
 

--- a/src/relay/context.ts
+++ b/src/relay/context.ts
@@ -165,22 +165,23 @@ class RelayContext extends EventEmitter {
         let resolvedPromiseName
 
         const pushPromise = (promise: Promise<any>, name: string) => {
-          promises.push(promise.then(res => { 
-            resolvedPromiseName = name
-            return res
-          }))
+          promises.push(
+            promise.then((res) => {
+              resolvedPromiseName = name
+              return res
+            })
+          )
         }
 
         // Wait for stream switches
-        pushPromise(this._streamSourceSwitchPromise.promise, "streamSwitch")
+        pushPromise(this._streamSourceSwitchPromise.promise, 'streamSwitch')
 
         // Wait for payload messages
         if (result == undefined || (result as StreamResult).done != true) {
           this._sourcePromise = this._sourcePromise ?? this._stream.source.next()
 
-          pushPromise(this._sourcePromise, "sourcePromise")
+          pushPromise(this._sourcePromise, 'sourcePromise')
         }
-
 
         this.verbose(`FLOW: relay_incoming: awaiting promises`)
         // 1. Handle Stream switches
@@ -250,7 +251,7 @@ class RelayContext extends EventEmitter {
           }
 
           next()
-          
+
           this.verbose(`FLOW: relay_incoming: got PING or PONG, continue`)
           continue
           // Interprete connection sub-protocol
@@ -259,7 +260,7 @@ class RelayContext extends EventEmitter {
             this.verbose(`STOP relayed`)
 
             this.emit('close')
-            
+
             this.verbose(`FLOW: relay_incoming: STOP relayed, break`)
             // forward STOP message
             yield received.value
@@ -278,7 +279,7 @@ class RelayContext extends EventEmitter {
 
         next()
       }
-      
+
       this.verbose(`FLOW: relay_incoming: loop ended`)
     }.call(this)
 
@@ -321,22 +322,24 @@ class RelayContext extends EventEmitter {
         let resolvedPromiseName
 
         const pushPromise = (promise: Promise<any>, name: string) => {
-          promises.push(promise.then(res => { 
-            resolvedPromiseName = name
-            return res
-          }))
-        }
-        
-        if (currentSource == undefined) {
-          pushPromise(this._sinkSourceAttachedPromise.promise, "sinkSourceAttacked")
+          promises.push(
+            promise.then((res) => {
+              resolvedPromiseName = name
+              return res
+            })
+          )
         }
 
-        pushPromise(this._statusMessagePromise.promise, "statusMessage")
+        if (currentSource == undefined) {
+          pushPromise(this._sinkSourceAttachedPromise.promise, 'sinkSourceAttacked')
+        }
+
+        pushPromise(this._statusMessagePromise.promise, 'statusMessage')
 
         if (currentSource != undefined && (result == undefined || (result as StreamResult).done != true)) {
           sourcePromise = sourcePromise ?? currentSource.next()
 
-          pushPromise(sourcePromise, "payload")
+          pushPromise(sourcePromise, 'payload')
         }
 
         // (0. Handle source attach)
@@ -399,7 +402,7 @@ class RelayContext extends EventEmitter {
 
         next()
         this.verbose(`FLOW: relay_outgoing: end of loop iteration`)
-        yield received.value        
+        yield received.value
       }
       this.verbose(`FLOW: relay_outgoing: loop ended`)
     }

--- a/src/webrtc/connection.ts
+++ b/src/webrtc/connection.ts
@@ -17,6 +17,7 @@ import abortable from 'abortable-iterator'
 const DEBUG_PREFIX = `hopr-connect`
 
 const _log = Debug(DEBUG_PREFIX)
+const _verbose = Debug('hopr-connect:verbose')
 const _error = Debug(DEBUG_PREFIX.concat(`error`))
 
 export const WEBRTC_UPGRADE_TIMEOUT = durations.seconds(3)
@@ -123,6 +124,13 @@ class WebRTCConnection implements MultiaddrConnection {
    */
   private log(..._: any[]) {
     _log(`WRTC [${this._id}]`, ...arguments)
+  }
+
+  /**
+   * Log verbose messages and add identity tag to distinguish multiple instances
+   */
+   private verbose(..._: any[]) {
+    _verbose(`WRTC [${this._id}]`, ...arguments)
   }
 
   /**

--- a/src/webrtc/connection.ts
+++ b/src/webrtc/connection.ts
@@ -129,7 +129,7 @@ class WebRTCConnection implements MultiaddrConnection {
   /**
    * Log verbose messages and add identity tag to distinguish multiple instances
    */
-   private verbose(..._: any[]) {
+  private verbose(..._: any[]) {
     _verbose(`WRTC [${this._id}]`, ...arguments)
   }
 
@@ -220,29 +220,31 @@ class WebRTCConnection implements MultiaddrConnection {
               this.verbose(`FLOW: webrtc sink: loop iteration`)
               const promises: Promise<SinkType>[] = []
 
-              let resolvedPromiseName 
+              let resolvedPromiseName
 
               const pushPromise = (promise: Promise<SinkType>, name: string) => {
-                promises.push(promise.then(res => { 
-                  resolvedPromiseName = name
-                  return res
-                }))
+                promises.push(
+                  promise.then((res) => {
+                    resolvedPromiseName = name
+                    return res
+                  })
+                )
               }
 
               // No source available, need to wait for it
               if (!sourceAttached) {
-                pushPromise(this._sinkSourceAttachedPromise.promise, "sourceAttached")
+                pushPromise(this._sinkSourceAttachedPromise.promise, 'sourceAttached')
               }
 
               // WebRTC handshake is not completed yet
               if (!webRTCFinished) {
-                pushPromise(this._switchPromise.promise, "switch")
+                pushPromise(this._switchPromise.promise, 'switch')
               }
 
               // Source already attached, wait for incoming messages
               if (sourceAttached) {
                 sourcePromise ??= (source as Stream['source']).next()
-                pushPromise(sourcePromise, "source")
+                pushPromise(sourcePromise, 'source')
               }
 
               // (0.) Handle stream source attach


### PR DESCRIPTION
This is purely for debugging purposes. During integration test all the nodes output their flow state messages prepended with `FLOW:` which are merged into a single flow log at `/var/tmp/hopr-connect-flow.log`. This can help analyze nodes' behavior in case of trouble.