### PR TITLE
free relay on webrtc upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,11 +48,15 @@
     "wrtc": "0.4.7"
   },
   "devDependencies": {
+    "@types/chai": "^4.2.21",
+    "@types/chai-spies": "^1.0.3",
     "@types/debug": "^4.1.7",
     "@types/mocha": "^9.0.0",
     "@types/node": "16",
     "@types/simple-peer": "^9.11.1",
     "@types/yargs": "^17.0.2",
+    "chai": "^4.3.4",
+    "chai-spies": "^1.0.0",
     "it-pair": "^1.0.0",
     "it-pipe": "^1.1.0",
     "it-pushable": "^1.4.2",

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -198,7 +198,7 @@ start_node tests/node.ts "${charly_log}" \
   --port ${charly_port} \
   --identityName 'charly' \
   --noDirectConnections true \
-  --noWebRTCUpgrade true \
+  --noWebRTCUpgrade false \
   --maxRelayedConnections 1
 
 
@@ -226,7 +226,7 @@ start_node tests/node.ts "${dave_log}" \
   --bootstrapPort ${charly_port} \
   --bootstrapIdentityName 'charly' \
   --noDirectConnections true \
-  --noWebRTCUpgrade true
+  --noWebRTCUpgrade false
 
 # run ed (client)
 # should try connecting to bob through relay charly after alice finishes talking to bob and succeed
@@ -252,7 +252,7 @@ start_node tests/node.ts "${ed_log}" \
   --bootstrapPort ${charly_port} \
   --bootstrapIdentityName 'charly' \
   --noDirectConnections true \
-  --noWebRTCUpgrade true
+  --noWebRTCUpgrade false
 
 # wait till nodes finish communicating
 wait_for_regex_in_file "${alice_log}" "all tasks executed"

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -166,7 +166,7 @@ start_node tests/node.ts \
     --bootstrapPort ${charly_port} \
     --bootstrapIdentityName 'charly' \
     --noDirectConnections true \
-    --noWebRTCUpgrade true \
+    --noWebRTCUpgrade false \
     
 # run bob (client)
 # should be able to receive 'test' from alice through charly
@@ -188,7 +188,7 @@ start_node tests/node.ts "${bob_log}"  \
   --bootstrapPort ${charly_port} \
   --bootstrapIdentityName 'charly' \
   --noDirectConnections true \
-  --noWebRTCUpgrade true \  
+  --noWebRTCUpgrade false \  
   
 # run charly
 # should able to serve as a bootstrap

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -233,7 +233,7 @@ start_node tests/node.ts "${dave_log}" \
 start_node tests/node.ts "${ed_log}" \
   "[ {
         'cmd': 'wait',
-        'waitForSecs': 5
+        'waitForSecs': 6
       },
       {
         'cmd': 'dial',

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -199,8 +199,8 @@ start_node tests/node.ts "${charly_log}" \
   --identityName 'charly' \
   --noDirectConnections true \
   --noWebRTCUpgrade false \
-  --maxRelayedConnections 1
-
+  --maxRelayedConnections 1 \
+  --relayFreeTimeout 2000 # to simulate relay being busy
 
 # run dave (client)
 # should try connecting to bob through relay charly and get RELAY_FULL error

--- a/src/base/listener.spec.ts
+++ b/src/base/listener.spec.ts
@@ -16,7 +16,9 @@ import { once, on, EventEmitter } from 'events'
 
 import { networkInterfaces } from 'os'
 import { u8aEquals } from '@hoprnet/hopr-utils'
+
 import type { PublicNodesEmitter, PeerStoreType } from '../types'
+
 
 /**
  * Decorated Listener class that emits events after

--- a/src/base/listener.spec.ts
+++ b/src/base/listener.spec.ts
@@ -19,7 +19,6 @@ import { u8aEquals } from '@hoprnet/hopr-utils'
 
 import type { PublicNodesEmitter, PeerStoreType } from '../types'
 
-
 /**
  * Decorated Listener class that emits events after
  * updating list of potential relays

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -41,7 +41,7 @@ export enum StatusMessages {
 export enum ConnectionStatusMessages {
   STOP,
   RESTART,
-  UPGRADED,
+  UPGRADED
 }
 
 export enum RelayPrefix {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -40,7 +40,8 @@ export enum StatusMessages {
 
 export enum ConnectionStatusMessages {
   STOP,
-  RESTART
+  RESTART,
+  UPGRADED,
 }
 
 export enum RelayPrefix {

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,8 +26,8 @@ export type HoprConnectOptions = {
   interface?: string
   __noDirectConnections?: boolean
   __noWebRTCUpgrade?: boolean
-  maxRelayedConnections?: number,
-  __relayFreeTimeout?: number,
+  maxRelayedConnections?: number
+  __relayFreeTimeout?: number
 }
 
 /**
@@ -102,7 +102,7 @@ class HoprConnect implements Transport {
       this._webRTCUpgrader,
       opts.__noWebRTCUpgrade,
       opts.maxRelayedConnections,
-      opts.__relayFreeTimeout,
+      opts.__relayFreeTimeout
     )
 
     // Used for testing

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,8 @@ export type HoprConnectOptions = {
   interface?: string
   __noDirectConnections?: boolean
   __noWebRTCUpgrade?: boolean
-  maxRelayedConnections?: number
+  maxRelayedConnections?: number,
+  __relayFreeTimeout?: number,
 }
 
 /**
@@ -100,7 +101,8 @@ class HoprConnect implements Transport {
       this.connHandler,
       this._webRTCUpgrader,
       opts.__noWebRTCUpgrade,
-      opts.maxRelayedConnections
+      opts.maxRelayedConnections,
+      opts.__relayFreeTimeout,
     )
 
     // Used for testing

--- a/src/relay/connection.ts
+++ b/src/relay/connection.ts
@@ -193,7 +193,10 @@ class RelayConnection extends EventEmitter implements MultiaddrConnection {
     this.verbose(`FLOW: close complete, finish`)
   }
 
-  sendUpgrade() {
+  /**
+   * Send UPGRADED status msg to the relay, so it can free the slot
+   */
+  sendUpgraded() {
     this.verbose(`FLOW: sending UPGRADED`)
      this.queueStatusMessage(Uint8Array.of(RelayPrefix.CONNECTION_STATUS, ConnectionStatusMessages.UPGRADED))
   }

--- a/src/relay/connection.ts
+++ b/src/relay/connection.ts
@@ -198,7 +198,7 @@ class RelayConnection extends EventEmitter implements MultiaddrConnection {
    */
   sendUpgraded() {
     this.verbose(`FLOW: sending UPGRADED`)
-     this.queueStatusMessage(Uint8Array.of(RelayPrefix.CONNECTION_STATUS, ConnectionStatusMessages.UPGRADED))
+    this.queueStatusMessage(Uint8Array.of(RelayPrefix.CONNECTION_STATUS, ConnectionStatusMessages.UPGRADED))
   }
 
   /**
@@ -514,7 +514,7 @@ class RelayConnection extends EventEmitter implements MultiaddrConnection {
             this._onReconnect(this.switch(), this._counterparty)
 
             continue
-          } 
+          }
         } else if (PREFIX[0] == RelayPrefix.STATUS_MESSAGE) {
           if (SUFFIX[0] == StatusMessages.PING) {
             this.verbose(`PING received`)

--- a/src/relay/connection.ts
+++ b/src/relay/connection.ts
@@ -193,6 +193,10 @@ class RelayConnection extends EventEmitter implements MultiaddrConnection {
     this.verbose(`FLOW: close complete, finish`)
   }
 
+  sendUpgrade() {
+     this.queueStatusMessage(Uint8Array.of(RelayPrefix.CONNECTION_STATUS, ConnectionStatusMessages.UPGRADED))
+  }
+
   /**
    * Log messages and add identity tag to distinguish multiple instances
    */
@@ -506,7 +510,7 @@ class RelayConnection extends EventEmitter implements MultiaddrConnection {
             this._onReconnect(this.switch(), this._counterparty)
 
             continue
-          }
+          } 
         } else if (PREFIX[0] == RelayPrefix.STATUS_MESSAGE) {
           if (SUFFIX[0] == StatusMessages.PING) {
             this.verbose(`PING received`)

--- a/src/relay/connection.ts
+++ b/src/relay/connection.ts
@@ -194,6 +194,7 @@ class RelayConnection extends EventEmitter implements MultiaddrConnection {
   }
 
   sendUpgrade() {
+    this.verbose(`FLOW: sending UPGRADED`)
      this.queueStatusMessage(Uint8Array.of(RelayPrefix.CONNECTION_STATUS, ConnectionStatusMessages.UPGRADED))
   }
 

--- a/src/relay/context.ts
+++ b/src/relay/context.ts
@@ -270,7 +270,9 @@ class RelayContext extends EventEmitter {
           } else if (SUFFIX[0] == ConnectionStatusMessages.UPGRADED) {
             // this is an artificial timeout to test the relay slot being properly freed during the integration test
             this.verbose(`FLOW: waiting ${this.relayFreeTimeout}ms before freeing relay`)
-            await new Promise((resolve) => setTimeout(resolve, this.relayFreeTimeout))
+            if (this.relayFreeTimeout > 0) {
+              await new Promise((resolve) => setTimeout(resolve, this.relayFreeTimeout))
+            }
             this.verbose(`FLOW: freeing relay`)
 
             this.emit('upgrade')

--- a/src/relay/context.ts
+++ b/src/relay/context.ts
@@ -38,14 +38,13 @@ class RelayContext extends EventEmitter {
   private _sourcePromise: Promise<StreamResult> | undefined
   private _sourceSwitched: boolean
 
-
   public source: Stream['source']
   public sink: Stream['sink']
 
   constructor(stream: Stream, private relayFreeTimeout: number = 0) {
     super()
     this._id = u8aToHex(randomBytes(4), false)
-  
+
     this._statusMessagePromise = Defer<void>()
     this._statusMessages = []
     this._stream = stream
@@ -271,12 +270,12 @@ class RelayContext extends EventEmitter {
           } else if (SUFFIX[0] == ConnectionStatusMessages.UPGRADED) {
             // this is an artificial timeout to test the relay slot being properly freed during the integration test
             this.verbose(`FLOW: waiting ${this.relayFreeTimeout}ms before freeing relay`)
-            await new Promise(resolve => setTimeout(resolve, this.relayFreeTimeout));
+            await new Promise((resolve) => setTimeout(resolve, this.relayFreeTimeout))
             this.verbose(`FLOW: freeing relay`)
 
-            this.emit('upgrade') 
+            this.emit('upgrade')
             next()
-            continue            
+            continue
           } else if ((SUFFIX[0] = ConnectionStatusMessages.RESTART)) {
             this.verbose(`RESTART relayed`)
             this.verbose(`FLOW: relay_incoming: RESTART relayed, break`)

--- a/src/relay/context.ts
+++ b/src/relay/context.ts
@@ -38,13 +38,14 @@ class RelayContext extends EventEmitter {
   private _sourcePromise: Promise<StreamResult> | undefined
   private _sourceSwitched: boolean
 
+
   public source: Stream['source']
   public sink: Stream['sink']
 
-  constructor(stream: Stream) {
+  constructor(stream: Stream, private relayFreeTimeout: number = 0) {
     super()
     this._id = u8aToHex(randomBytes(4), false)
-
+  
     this._statusMessagePromise = Defer<void>()
     this._statusMessages = []
     this._stream = stream
@@ -270,7 +271,10 @@ class RelayContext extends EventEmitter {
           } else if (SUFFIX[0] == ConnectionStatusMessages.UPGRADED) {
             this.verbose(`UPGRADED relayed`)
 
-            await new Promise(resolve => setTimeout(resolve, 2000));
+            // this is an artificial timeout to test the relay slot being properly freed during the integration test
+            this.verbose(`FLOW: waiting ${this.relayFreeTimeout}ms before freeing relay`)
+            await new Promise(resolve => setTimeout(resolve, this.relayFreeTimeout));
+            this.verbose(`FLOW: freeing relay`)
 
             this.emit('upgrade') 
             next()

--- a/src/relay/context.ts
+++ b/src/relay/context.ts
@@ -269,8 +269,6 @@ class RelayContext extends EventEmitter {
             // close stream
             break
           } else if (SUFFIX[0] == ConnectionStatusMessages.UPGRADED) {
-            this.verbose(`UPGRADED relayed`)
-
             // this is an artificial timeout to test the relay slot being properly freed during the integration test
             this.verbose(`FLOW: waiting ${this.relayFreeTimeout}ms before freeing relay`)
             await new Promise(resolve => setTimeout(resolve, this.relayFreeTimeout));

--- a/src/relay/context.ts
+++ b/src/relay/context.ts
@@ -268,16 +268,16 @@ class RelayContext extends EventEmitter {
             // close stream
             break
           } else if (SUFFIX[0] == ConnectionStatusMessages.UPGRADED) {
-            this.verbose(`STOP relayed`)
+            this.verbose(`UPGRADED relayed`)
 
-            this.emit('close')
+            // this.emit('close')
 
-            this.verbose(`FLOW: relay_incoming: STOP relayed, break`)
-            // forward STOP message
-            yield received.value
-
+            // this.verbose(`FLOW: relay_incoming: STOP relayed, break`)
+            // forward UPGRADED message
+            next()
+            continue
             // close stream
-            break
+            // break
           } else if ((SUFFIX[0] = ConnectionStatusMessages.RESTART)) {
             this.verbose(`RESTART relayed`)
             this.verbose(`FLOW: relay_incoming: RESTART relayed, break`)

--- a/src/relay/context.ts
+++ b/src/relay/context.ts
@@ -269,6 +269,9 @@ class RelayContext extends EventEmitter {
             break
           } else if (SUFFIX[0] == ConnectionStatusMessages.UPGRADED) {
             this.verbose(`UPGRADED relayed`)
+
+            await new Promise(resolve => setTimeout(resolve, 2000));
+
             this.emit('upgrade') 
             next()
             continue

--- a/src/relay/context.ts
+++ b/src/relay/context.ts
@@ -269,11 +269,7 @@ class RelayContext extends EventEmitter {
             break
           } else if (SUFFIX[0] == ConnectionStatusMessages.UPGRADED) {
             this.verbose(`UPGRADED relayed`)
-
-            // this.emit('close')
-
-            // this.verbose(`FLOW: relay_incoming: STOP relayed, break`)
-            // forward UPGRADED message
+            this.emit('upgrade') 
             next()
             continue
             // close stream

--- a/src/relay/context.ts
+++ b/src/relay/context.ts
@@ -276,9 +276,7 @@ class RelayContext extends EventEmitter {
 
             this.emit('upgrade') 
             next()
-            continue
-            // close stream
-            // break
+            continue            
           } else if ((SUFFIX[0] = ConnectionStatusMessages.RESTART)) {
             this.verbose(`RESTART relayed`)
             this.verbose(`FLOW: relay_incoming: RESTART relayed, break`)

--- a/src/relay/context.ts
+++ b/src/relay/context.ts
@@ -267,6 +267,17 @@ class RelayContext extends EventEmitter {
 
             // close stream
             break
+          } else if (SUFFIX[0] == ConnectionStatusMessages.UPGRADED) {
+            this.verbose(`STOP relayed`)
+
+            this.emit('close')
+
+            this.verbose(`FLOW: relay_incoming: STOP relayed, break`)
+            // forward STOP message
+            yield received.value
+
+            // close stream
+            break
           } else if ((SUFFIX[0] = ConnectionStatusMessages.RESTART)) {
             this.verbose(`RESTART relayed`)
             this.verbose(`FLOW: relay_incoming: RESTART relayed, break`)

--- a/src/relay/handshake.ts
+++ b/src/relay/handshake.ts
@@ -168,7 +168,7 @@ class RelayHandshake {
     isActive: InstanceType<typeof RelayState>['isActive'],
     updateExisting: InstanceType<typeof RelayState>['updateExisting'],
     createNew: InstanceType<typeof RelayState>['createNew'],
-    relayFreeTimeout?: number
+    __relayFreeTimeout?: number
   ): Promise<void> {
     log(`handling relay request`)
 
@@ -270,7 +270,7 @@ class RelayHandshake {
         this.shaker.rest()
         destinationShaker.rest()
 
-        createNew(source, destination, this.shaker.stream, destinationShaker.stream, relayFreeTimeout)
+        createNew(source, destination, this.shaker.stream, destinationShaker.stream, __relayFreeTimeout)
         break
       default:
         this.shaker.write(Uint8Array.of(RelayHandshakeMessage.FAIL_COULD_NOT_REACH_COUNTERPARTY))

--- a/src/relay/handshake.ts
+++ b/src/relay/handshake.ts
@@ -167,7 +167,8 @@ class RelayHandshake {
     exists: InstanceType<typeof RelayState>['exists'],
     isActive: InstanceType<typeof RelayState>['isActive'],
     updateExisting: InstanceType<typeof RelayState>['updateExisting'],
-    createNew: InstanceType<typeof RelayState>['createNew']
+    createNew: InstanceType<typeof RelayState>['createNew'],
+    relayFreeTimeout?: number
   ): Promise<void> {
     log(`handling relay request`)
 
@@ -269,7 +270,7 @@ class RelayHandshake {
         this.shaker.rest()
         destinationShaker.rest()
 
-        createNew(source, destination, this.shaker.stream, destinationShaker.stream)
+        createNew(source, destination, this.shaker.stream, destinationShaker.stream, relayFreeTimeout)
         break
       default:
         this.shaker.write(Uint8Array.of(RelayHandshakeMessage.FAIL_COULD_NOT_REACH_COUNTERPARTY))

--- a/src/relay/index.ts
+++ b/src/relay/index.ts
@@ -68,14 +68,14 @@ class Relay {
         log(`relayed request rejected, already at max capacity (${this.maxRelayedConnections})`)
         shaker.reject(RelayHandshakeMessage.FAIL_RELAY_FULL)
       } else {
-        shaker.negotiate(          
-          connection.remotePeer,          
+        shaker.negotiate(
+          connection.remotePeer,
           (counterparty: PeerId) => this.contactCounterparty(counterparty),
           this.relayState.exists.bind(this.relayState),
           this.relayState.isActive.bind(this.relayState),
           this.relayState.updateExisting.bind(this.relayState),
           this.relayState.createNew.bind(this.relayState),
-          this.__relayFreeTimeout,
+          this.__relayFreeTimeout
         )
       }
     })

--- a/src/relay/index.ts
+++ b/src/relay/index.ts
@@ -47,7 +47,8 @@ class Relay {
     private connHandler: ConnHandler | undefined,
     private webRTCUpgrader?: WebRTCUpgrader,
     private __noWebRTCUpgrade?: boolean,
-    private maxRelayedConnections: number = DEFAULT_MAX_RELAYED_CONNECTIONS
+    private maxRelayedConnections: number = DEFAULT_MAX_RELAYED_CONNECTIONS,
+    private __relayFreeTimeout?: number
   ) {
     this.relayState = new RelayState()
 
@@ -68,13 +69,14 @@ class Relay {
         log(`relayed request rejected, already at max capacity (${this.maxRelayedConnections})`)
         shaker.reject(RelayHandshakeMessage.FAIL_RELAY_FULL)
       } else {
-        shaker.negotiate(
-          connection.remotePeer,
+        shaker.negotiate(          
+          connection.remotePeer,          
           (counterparty: PeerId) => this.contactCounterparty(counterparty),
           this.relayState.exists.bind(this.relayState),
           this.relayState.isActive.bind(this.relayState),
           this.relayState.updateExisting.bind(this.relayState),
-          this.relayState.createNew.bind(this.relayState)
+          this.relayState.createNew.bind(this.relayState),
+          this.__relayFreeTimeout,
         )
       }
     })

--- a/src/relay/index.ts
+++ b/src/relay/index.ts
@@ -5,8 +5,7 @@
 import debug from 'debug'
 
 const DEBUG_PREFIX = 'hopr-connect:relay'
-// @TODO change this once freeing relay slot is working
-const DEFAULT_MAX_RELAYED_CONNECTIONS = Infinity
+const DEFAULT_MAX_RELAYED_CONNECTIONS = 10
 
 const log = debug(DEBUG_PREFIX)
 const error = debug(DEBUG_PREFIX.concat(':error'))

--- a/src/relay/state.spec.ts
+++ b/src/relay/state.spec.ts
@@ -54,7 +54,6 @@ describe('relay state management', function () {
     })
 
     state.createNew(
-      0,
       initiator,
       destination,
       {
@@ -157,7 +156,6 @@ describe('relay state management', function () {
     })
 
     state.createNew(
-      0, 
       initiator,
       destination,
       {

--- a/src/relay/state.spec.ts
+++ b/src/relay/state.spec.ts
@@ -54,6 +54,7 @@ describe('relay state management', function () {
     })
 
     state.createNew(
+      0,
       initiator,
       destination,
       {
@@ -156,6 +157,7 @@ describe('relay state management', function () {
     })
 
     state.createNew(
+      0, 
       initiator,
       destination,
       {

--- a/src/relay/state.ts
+++ b/src/relay/state.ts
@@ -99,9 +99,9 @@ class RelayState {
    * @param toSource duplex stream to source
    * @param toDestination duplex stream to destination
    */
-  createNew(source: PeerId, destination: PeerId, toSource: Stream, toDestination: Stream, relayFreeTimeout?: number) {
-    const toSourceContext = new RelayContext(toSource, relayFreeTimeout)
-    const toDestinationContext = new RelayContext(toDestination, relayFreeTimeout)
+  createNew(source: PeerId, destination: PeerId, toSource: Stream, toDestination: Stream, __relayFreeTimeout?: number) {
+    const toSourceContext = new RelayContext(toSource, __relayFreeTimeout)
+    const toDestinationContext = new RelayContext(toDestination, __relayFreeTimeout)
 
     toSourceContext.sink(toDestinationContext.source)
     toDestinationContext.sink(toSourceContext.source)

--- a/src/relay/state.ts
+++ b/src/relay/state.ts
@@ -114,6 +114,9 @@ class RelayState {
     toSourceContext.once('close', this.cleanListener(source, destination))
     toSourceContext.once('close', this.cleanListener(destination, source))
 
+    toSourceContext.once('upgrade', this.cleanListener(source, destination))
+    toSourceContext.once('upgrade', this.cleanListener(destination, source))
+
     this.relayedConnections.set(RelayState.getId(source, destination), relayedConnection)
   }
 
@@ -125,6 +128,8 @@ class RelayState {
    */
   private cleanListener(source: PeerId, destination: PeerId): () => void {
     return function (this: RelayState) {
+      console.trace()
+      console.log(`cleaning listner ${source} - ${destination}`)
       const id = RelayState.getId(source, destination)
 
       let found = this.relayedConnections.get(id)

--- a/src/relay/state.ts
+++ b/src/relay/state.ts
@@ -99,9 +99,9 @@ class RelayState {
    * @param toSource duplex stream to source
    * @param toDestination duplex stream to destination
    */
-  createNew(source: PeerId, destination: PeerId, toSource: Stream, toDestination: Stream) {
-    const toSourceContext = new RelayContext(toSource)
-    const toDestinationContext = new RelayContext(toDestination)
+  createNew(source: PeerId, destination: PeerId, toSource: Stream, toDestination: Stream, relayFreeTimeout?: number) {
+    const toSourceContext = new RelayContext(toSource, relayFreeTimeout)
+    const toDestinationContext = new RelayContext(toDestination, relayFreeTimeout)
 
     toSourceContext.sink(toDestinationContext.source)
     toDestinationContext.sink(toSourceContext.source)

--- a/src/relay/state.ts
+++ b/src/relay/state.ts
@@ -128,8 +128,7 @@ class RelayState {
    */
   private cleanListener(source: PeerId, destination: PeerId): () => void {
     return function (this: RelayState) {
-      console.trace()
-      console.log(`cleaning listner ${source} - ${destination}`)
+      console.log(`FLOW: cleaning listener, source: ${source}, dest: ${destination}`)
       const id = RelayState.getId(source, destination)
 
       let found = this.relayedConnections.get(id)

--- a/src/relay/state.ts
+++ b/src/relay/state.ts
@@ -128,7 +128,6 @@ class RelayState {
    */
   private cleanListener(source: PeerId, destination: PeerId): () => void {
     return function (this: RelayState) {
-      console.log(`FLOW: cleaning listener, source: ${source}, dest: ${destination}`)
       const id = RelayState.getId(source, destination)
 
       let found = this.relayedConnections.get(id)

--- a/src/webrtc/connection.spec.ts
+++ b/src/webrtc/connection.spec.ts
@@ -26,7 +26,8 @@ describe('test webrtc connection', function () {
       { connections: new Map() } as any,
       {
         source: BobAlice.source,
-        sink: AliceBob.sink
+        sink: AliceBob.sink,
+        sendUpgraded: () => {}
       } as any,
       new EventEmitter() as any
     )
@@ -63,7 +64,8 @@ describe('test webrtc connection', function () {
       { connections: new Map() } as any,
       {
         source: BobAlice.source,
-        sink: AliceBob.sink
+        sink: AliceBob.sink,
+        sendUpgraded: () => {}
       } as any,
       webRTCInstance as any
     )
@@ -128,7 +130,8 @@ describe('test webrtc connection', function () {
       { connections: new Map() } as any,
       {
         source: BobAlice.source,
-        sink: AliceBob.sink
+        sink: AliceBob.sink,
+        sendUpgraded: () => {}
       } as any,
       webRTCInstance as any
     )
@@ -187,7 +190,8 @@ describe('test webrtc connection', function () {
       {
         source: BobAlice.source,
         sink: AliceBob.sink,
-        remoteAddr: new Multiaddr(`/p2p/${Bob.toB58String()}`)
+        remoteAddr: new Multiaddr(`/p2p/${Bob.toB58String()}`),
+        sendUpgraded: () => {}
       } as any,
       webRTCInstance as any
     )

--- a/src/webrtc/connection.spec.ts
+++ b/src/webrtc/connection.spec.ts
@@ -71,7 +71,7 @@ describe('test webrtc connection', function () {
       {
         source: BobAlice.source,
         sink: AliceBob.sink,
-        sendUpgraded: sendUpgradedSpy,
+        sendUpgraded: sendUpgradedSpy
       } as any,
       webRTCInstance as any
     )
@@ -84,7 +84,7 @@ describe('test webrtc connection', function () {
     webRTCInstance.emit(`connect`)
 
     assert(u8aEquals((await BobShaker.read()).slice(), Uint8Array.of(MigrationStatus.DONE)))
-  
+
     expect(sendUpgradedSpy).to.have.been.called.once
   })
 

--- a/src/webrtc/connection.ts
+++ b/src/webrtc/connection.ts
@@ -303,8 +303,9 @@ class WebRTCConnection implements MultiaddrConnection {
         )
       )
     )
-    this.verbose(`FLOW: webrtc sink 2`)
-
+    this.verbose(`FLOW: waiting before sending UPGRADED`)
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    this.verbose(`FLOW: finished waiting`)
     this.relayConn.sendUpgrade()
 
     // Either stream is finished or WebRTC is available

--- a/src/webrtc/connection.ts
+++ b/src/webrtc/connection.ts
@@ -304,7 +304,7 @@ class WebRTCConnection implements MultiaddrConnection {
       )
     )
     this.verbose(`FLOW: waiting before sending UPGRADED`)
-    await new Promise(resolve => setTimeout(resolve, 1000));
+    // await new Promise(resolve => setTimeout(resolve, 1000));
     this.verbose(`FLOW: finished waiting`)
     this.relayConn.sendUpgrade()
 

--- a/src/webrtc/connection.ts
+++ b/src/webrtc/connection.ts
@@ -303,13 +303,12 @@ class WebRTCConnection implements MultiaddrConnection {
         )
       )
     )
-    this.verbose(`FLOW: sending UPGRADED to relay`)
-    this.relayConn.sendUpgraded()
-
     // Either stream is finished or WebRTC is available
 
     if (this._webRTCAvailable) {
-      this.verbose(`FLOW: webrtc available, next sink`)
+      this.verbose(`FLOW: sending UPGRADED to relay`)
+      this.relayConn.sendUpgraded()
+      
       // WebRTC handshake was successful, now using direct connection
       this._sinkMigrated = true
       if (this._sourceMigrated) {

--- a/src/webrtc/connection.ts
+++ b/src/webrtc/connection.ts
@@ -303,9 +303,7 @@ class WebRTCConnection implements MultiaddrConnection {
         )
       )
     )
-    this.verbose(`FLOW: waiting before sending UPGRADED`)
-    // await new Promise(resolve => setTimeout(resolve, 1000));
-    this.verbose(`FLOW: finished waiting`)
+    this.verbose(`FLOW: sending UPGRADED to relay`)
     this.relayConn.sendUpgraded()
 
     // Either stream is finished or WebRTC is available

--- a/src/webrtc/connection.ts
+++ b/src/webrtc/connection.ts
@@ -308,7 +308,7 @@ class WebRTCConnection implements MultiaddrConnection {
     if (this._webRTCAvailable) {
       this.verbose(`FLOW: sending UPGRADED to relay`)
       this.relayConn.sendUpgraded()
-      
+
       // WebRTC handshake was successful, now using direct connection
       this._sinkMigrated = true
       if (this._sourceMigrated) {

--- a/src/webrtc/connection.ts
+++ b/src/webrtc/connection.ts
@@ -115,6 +115,7 @@ class WebRTCConnection implements MultiaddrConnection {
     this.sink = this._sink.bind(this)
 
     this.sinkFunction()
+    this.verbose(`!!! sinkFunction`)
 
     this.webRTCHandshakeTimeout = setTimeout(this.afterWebRTCUpgrade.bind(this), WEBRTC_UPGRADE_TIMEOUT)
   }
@@ -200,6 +201,8 @@ class WebRTCConnection implements MultiaddrConnection {
 
     let sourceAttached = false
 
+    this.verbose(`FLOW: webrtc sink 1`)
+    
     // First: use relayed connection
     await new Promise<void>((resolve) =>
       this.relayConn.sink(
@@ -300,12 +303,14 @@ class WebRTCConnection implements MultiaddrConnection {
         )
       )
     )
-    
+    this.verbose(`FLOW: webrtc sink 2`)
+
     this.relayConn.sendUpgrade()
 
     // Either stream is finished or WebRTC is available
 
     if (this._webRTCAvailable) {
+      this.verbose(`FLOW: webrtc available, next sink`)
       // WebRTC handshake was successful, now using direct connection
       this._sinkMigrated = true
       if (this._sourceMigrated) {

--- a/src/webrtc/connection.ts
+++ b/src/webrtc/connection.ts
@@ -306,7 +306,7 @@ class WebRTCConnection implements MultiaddrConnection {
     this.verbose(`FLOW: waiting before sending UPGRADED`)
     // await new Promise(resolve => setTimeout(resolve, 1000));
     this.verbose(`FLOW: finished waiting`)
-    this.relayConn.sendUpgrade()
+    this.relayConn.sendUpgraded()
 
     // Either stream is finished or WebRTC is available
 
@@ -424,7 +424,7 @@ class WebRTCConnection implements MultiaddrConnection {
 
         if (done) {
           this.verbose(`FLOW: `)
-          this.relayConn.sendUpgrade()
+          this.relayConn.sendUpgraded()
           break
         }
       }

--- a/src/webrtc/connection.ts
+++ b/src/webrtc/connection.ts
@@ -154,7 +154,7 @@ class WebRTCConnection implements MultiaddrConnection {
     this._webRTCHandshakeFinished = true
     this._webRTCAvailable = false
     this._switchPromise.resolve()
-   
+
     setImmediate(() => {
       this.channel.destroy()
     })
@@ -202,7 +202,7 @@ class WebRTCConnection implements MultiaddrConnection {
     let sourceAttached = false
 
     this.verbose(`FLOW: webrtc sink 1`)
-    
+
     // First: use relayed connection
     await new Promise<void>((resolve) =>
       this.relayConn.sink(
@@ -273,7 +273,7 @@ class WebRTCConnection implements MultiaddrConnection {
                   // Send DONE and migrate to direct WebRTC connection
                   this.verbose(`FLOW: webrtc sink: webrtc finished, handle`)
                   // this.verbose(`FLOW: switched to webrtc, will try to close relayed connection`)
-            
+
                   yield Uint8Array.of(MigrationStatus.DONE)
                   break
                 } else {

--- a/src/webrtc/connection.ts
+++ b/src/webrtc/connection.ts
@@ -153,7 +153,7 @@ class WebRTCConnection implements MultiaddrConnection {
     this._webRTCHandshakeFinished = true
     this._webRTCAvailable = false
     this._switchPromise.resolve()
-
+   
     setImmediate(() => {
       this.channel.destroy()
     })
@@ -269,6 +269,8 @@ class WebRTCConnection implements MultiaddrConnection {
                 if (this._webRTCAvailable) {
                   // Send DONE and migrate to direct WebRTC connection
                   this.verbose(`FLOW: webrtc sink: webrtc finished, handle`)
+                  // this.verbose(`FLOW: switched to webrtc, will try to close relayed connection`)
+            
                   yield Uint8Array.of(MigrationStatus.DONE)
                   break
                 } else {
@@ -298,6 +300,8 @@ class WebRTCConnection implements MultiaddrConnection {
         )
       )
     )
+    
+    this.relayConn.sendUpgrade()
 
     // Either stream is finished or WebRTC is available
 
@@ -413,6 +417,8 @@ class WebRTCConnection implements MultiaddrConnection {
         }
 
         if (done) {
+          this.verbose(`FLOW: `)
+          this.relayConn.sendUpgrade()
           break
         }
       }

--- a/tests/node.ts
+++ b/tests/node.ts
@@ -69,7 +69,8 @@ async function startNode({
   noDirectConnections,
   noWebRTCUpgrade,
   pipeFileStream,
-  maxRelayedConnections
+  maxRelayedConnections,
+  relayFreeTimeout,
 }: {
   peerId: PeerId
   port: number
@@ -78,13 +79,15 @@ async function startNode({
   noWebRTCUpgrade: boolean
   pipeFileStream?: WriteStream
   maxRelayedConnections?: number
+  relayFreeTimeout?: number
 }) {
   console.log(`starting node, bootstrap address ${bootstrapAddress}`)
   const connectOpts: HoprConnectOptions = {
     initialNodes: bootstrapAddress ? [bootstrapAddress] : [],
     __noDirectConnections: noDirectConnections,
     __noWebRTCUpgrade: noWebRTCUpgrade,
-    maxRelayedConnections
+    maxRelayedConnections,
+    __relayFreeTimeout: relayFreeTimeout,
   }
 
   const node = await libp2p.create({
@@ -256,6 +259,9 @@ async function main() {
     .option('maxRelayedConnections', {
       type: 'number'
     })
+    .option('relayFreeTimeout', {
+      type: 'number'
+    })
     .coerce({
       script: (input) => JSON.parse(input.replace(/'/g, '"'))
     })
@@ -285,7 +291,8 @@ async function main() {
     noDirectConnections: argv.noDirectConnections,
     noWebRTCUpgrade: argv.noWebRTCUpgrade,
     pipeFileStream,
-    maxRelayedConnections: argv.maxRelayedConnections
+    maxRelayedConnections: argv.maxRelayedConnections,
+    relayFreeTimeout: argv.relayFreeTimeout
   })
 
   await executeCommands({ node, cmds: argv.script, pipeFileStream })

--- a/tests/node.ts
+++ b/tests/node.ts
@@ -70,7 +70,7 @@ async function startNode({
   noWebRTCUpgrade,
   pipeFileStream,
   maxRelayedConnections,
-  relayFreeTimeout,
+  relayFreeTimeout
 }: {
   peerId: PeerId
   port: number
@@ -87,7 +87,7 @@ async function startNode({
     __noDirectConnections: noDirectConnections,
     __noWebRTCUpgrade: noWebRTCUpgrade,
     maxRelayedConnections,
-    __relayFreeTimeout: relayFreeTimeout,
+    __relayFreeTimeout: relayFreeTimeout
   }
 
   const node = await libp2p.create({

--- a/yarn.lock
+++ b/yarn.lock
@@ -408,6 +408,8 @@ __metadata:
   resolution: "@hoprnet/hopr-connect@workspace:."
   dependencies:
     "@hoprnet/hopr-utils": 1.75.0-next.19
+    "@types/chai": ^4.2.21
+    "@types/chai-spies": ^1.0.3
     "@types/debug": ^4.1.7
     "@types/mocha": ^9.0.0
     "@types/node": 16
@@ -416,6 +418,8 @@ __metadata:
     abort-controller: 3.0.0
     abortable-iterator: ^3.0.0
     bl: ^5.0
+    chai: ^4.3.4
+    chai-spies: ^1.0.0
     debug: ^4.3.2
     heap-js: ^2.1.6
     it-handshake: ^2.0.0
@@ -747,6 +751,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/chai-spies@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "@types/chai-spies@npm:1.0.3"
+  dependencies:
+    "@types/chai": "*"
+  checksum: 2cb0bf2d30648281048cd721e85f201e8d2469eabcd42553036fd05cb94c034bb83625173fe409abab4c8244436c5d8979ede8b8b7bbd577e79f91abab22faa8
+  languageName: node
+  linkType: hard
+
+"@types/chai@npm:*, @types/chai@npm:^4.2.21":
+  version: 4.2.21
+  resolution: "@types/chai@npm:4.2.21"
+  checksum: fc7d32fbae47ad6d3576bcb8cf24a243af03c93bb97cd9456a5415da888ab78a03800dcc4cc25a21ad1b493bcdaee7377f163bc4dd8db463c3530dafddea205c
+  languageName: node
+  linkType: hard
+
 "@types/debug@npm:^4.1.7":
   version: 4.1.7
   resolution: "@types/debug@npm:4.1.7"
@@ -1041,6 +1061,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"assertion-error@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "assertion-error@npm:1.1.0"
+  checksum: 7bbc9fa2ff51618b0ea3c4ae13dbafe6dfb71b11c267aa93c749489355f55d0b844403bfc3dc8b9a98b0f21837fa2b59191c8a8f76e65303d06498fab4867f4c
+  languageName: node
+  linkType: hard
+
 "async@npm:^3.2.0":
   version: 3.2.0
   resolution: "async@npm:3.2.0"
@@ -1278,6 +1305,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chai-spies@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "chai-spies@npm:1.0.0"
+  peerDependencies:
+    chai: "*"
+  checksum: d7182238fca0b9e3da1b4b7e05ae5bff9e464795e48889a57ebf63b120b34e09a7fe6ad9f54bebd6fc9310f3f34abec7da71305cb90fd30f6b9e52eeaec95206
+  languageName: node
+  linkType: hard
+
+"chai@npm:^4.3.4":
+  version: 4.3.4
+  resolution: "chai@npm:4.3.4"
+  dependencies:
+    assertion-error: ^1.1.0
+    check-error: ^1.0.2
+    deep-eql: ^3.0.1
+    get-func-name: ^2.0.0
+    pathval: ^1.1.1
+    type-detect: ^4.0.5
+  checksum: ea3e6547b9a8d367f203e83b71632ec6a801f6380393594907968479aea15e411e4317211f46e03eda092a97f6812118b69b05bbded51b01224d193cc3f4b9b3
+  languageName: node
+  linkType: hard
+
 "chalk@npm:^4.1.0, chalk@npm:^4.1.1":
   version: 4.1.1
   resolution: "chalk@npm:4.1.1"
@@ -1285,6 +1335,13 @@ __metadata:
     ansi-styles: ^4.1.0
     supports-color: ^7.1.0
   checksum: 445c12db7aeed0046500a1e4184d31209a77d165654c885a789c41c8598a6a95bd2392180987cac572c967b93a2a730dda778bb7f87fa06ca63fd8592f8cc59f
+  languageName: node
+  linkType: hard
+
+"check-error@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "check-error@npm:1.0.2"
+  checksum: 1460ad12da600b277575f53b7512d6e59005a34e3235ae62cfe12ff5d83b68a6ff568841907eb5f041c3f468d1385ea9fcfd22344df02175d28ea8a8b9330940
   languageName: node
   linkType: hard
 
@@ -1463,6 +1520,15 @@ __metadata:
   version: 4.0.0
   resolution: "decamelize@npm:4.0.0"
   checksum: 3846161a3b6ba7043dd0e8cb8101676fcbd92a60bd228e63fe17116ebfaddff8d730e33c9e93a9e02c049c53e0e37013174225f27b95bb21d703359999a4aab9
+  languageName: node
+  linkType: hard
+
+"deep-eql@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "deep-eql@npm:3.0.1"
+  dependencies:
+    type-detect: ^4.0.0
+  checksum: eff42bc2d4d889dec8fd925fa9c013fa4d641842b98b502f436b9f2865460c8330f79fb7dbdb924a1e844b97b40843ed952f3847fb1e388a35bd4ef6e3d64184
   languageName: node
   linkType: hard
 
@@ -1912,6 +1978,13 @@ fsevents@~2.3.2:
   version: 2.0.5
   resolution: "get-caller-file@npm:2.0.5"
   checksum: 9dd9e1e2591039ee4c38c897365b904f66f1e650a8c1cb7b7db8ce667fa63e88cc8b13282b74df9d93de481114b3304a0487880d31cd926dfda6efe71455855d
+  languageName: node
+  linkType: hard
+
+"get-func-name@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "get-func-name@npm:2.0.0"
+  checksum: c72d3857cd05338fc61e52c385da67d553e42c226e141da11684aecb3e017a753bf7120411731fbc30768edf68f9c359dc202757703b3a851da54b2b17a9828d
   languageName: node
   linkType: hard
 
@@ -3728,6 +3801,13 @@ fsevents@~2.3.2:
   languageName: node
   linkType: hard
 
+"pathval@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "pathval@npm:1.1.1"
+  checksum: 81cd01d46cd0cd90fb7a8e0d576f8cb4cbbd0832ed00da14362be32ad79e855cf8ecf7e92fc0c267fdfc2766bd1d8fb3de43a51081e142ffb1fc814958fb8d8f
+  languageName: node
+  linkType: hard
+
 "peer-id@npm:0.15.2, peer-id@npm:~0.15.2":
   version: 0.15.2
   resolution: "peer-id@npm:0.15.2"
@@ -4523,6 +4603,13 @@ fsevents@~2.3.2:
   version: 0.14.5
   resolution: "tweetnacl@npm:0.14.5"
   checksum: e1c9d52e2e9f582fd0df9ea26ba5a9ab88b9a38b69625d8e55c5e8870a4832ac8c32f8854b41fce7b59f97258bb103535363f9eda7050aa70e75824b972c7dde
+  languageName: node
+  linkType: hard
+
+"type-detect@npm:^4.0.0, type-detect@npm:^4.0.5":
+  version: 4.0.8
+  resolution: "type-detect@npm:4.0.8"
+  checksum: e01dc6ac9098192a7859fb86c7b4073709a4e13a5cc02c54d54412378bb099563fda7a7a85640f33e3a7c2e8189182eb1511f263e67f402b2d63fe81afdde785
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #208

This PR addresses an issue when relay is unaware of the situation when connection between nodes has been upgaded to webrtc and therefore reached it's capacity. A new status message `UPGRADED` was introduced to allow the relay to gracefully release the slot.