### PR TITLE
Improve population of potential relays and cleaning up potential relays

### DIFF
--- a/src/base/listener.ts
+++ b/src/base/listener.ts
@@ -163,25 +163,25 @@ class Listener extends EventEmitter implements InterfaceListener {
       return
     }
 
-    let existingEntry = this.publicNodes.find((entry: NodeEntry) => entry.id.equals(peer.id))
+    let entry = this.publicNodes.find((entry: NodeEntry) => entry.id.equals(peer.id))
 
-    if (existingEntry != undefined) {
-      const newAddresses = usableAddresses.filter((ma: Multiaddr) => !existingEntry!.multiaddrs.includes(ma))
+    if (entry != undefined) {
+      const newAddresses = usableAddresses.filter((ma: Multiaddr) => !entry!.multiaddrs.includes(ma))
 
       if (newAddresses.length == 0) {
         // Nothing added so we can stop
         return
       }
 
-      existingEntry.multiaddrs = newAddresses.concat(existingEntry.multiaddrs)
+      entry.multiaddrs = newAddresses.concat(entry.multiaddrs)
     } else {
-      existingEntry = {
+      entry = {
         id: peer.id,
         multiaddrs: peer.multiaddrs,
         latency: Infinity
       }
 
-      this.publicNodes.push(existingEntry)
+      this.publicNodes.push(entry)
     }
 
     if (this.state != State.LISTENING) {

--- a/src/base/listener.ts
+++ b/src/base/listener.ts
@@ -5,7 +5,7 @@ import net, { AddressInfo, Socket as TCPSocket } from 'net'
 import dgram, { RemoteInfo } from 'dgram'
 
 import { once, EventEmitter } from 'events'
-import { PublicNodesEmitter } from '../types'
+import { PeerStoreType, PublicNodesEmitter } from '../types'
 import debug from 'debug'
 import { green, red } from 'chalk'
 import { NetworkInterfaceInfo, networkInterfaces } from 'os'
@@ -23,7 +23,6 @@ import { handleStunRequest, getExternalIp } from './stun'
 import { getAddrs } from './addrs'
 import { isAnyAddress } from '../utils'
 import { TCPConnection } from './tcp'
-import { u8aEquals } from '@hoprnet/hopr-utils'
 
 const log = debug('hopr-connect:listener')
 const error = debug('hopr-connect:listener:error')
@@ -49,54 +48,18 @@ async function attemptClose(maConn: MultiaddrConnection) {
   }
 }
 
-type NodeEntry = {
+type NodeEntry = PeerStoreType & {
   latency: number
-  peerId?: string
-  multiAddr: Multiaddr
 }
 
 function latencyCompare(a: NodeEntry, b: NodeEntry) {
   return a.latency - b.latency
 }
 
-function removeNodeFromList(nodeList: NodeEntry[], ma: Multiaddr): NodeEntry[] {
-  const result = []
-
-  const maTuples = ma.tuples()
-  const maPeerId = ma.getPeerId()
-
-  for (const entry of nodeList) {
-    const tuples = entry.multiAddr.tuples()
-
-    // Check if same peerId -> duplicate
-    if (maPeerId != null && maPeerId === entry.peerId) {
-      continue
-    }
-
-    // Check if same address:port
-    if (
-      u8aEquals(maTuples[0][1] as Uint8Array, tuples[0][1] as Uint8Array) &&
-      u8aEquals(maTuples[1][1] as Uint8Array, tuples[1][1] as Uint8Array)
-    ) {
-      continue
-    }
-
-    result.push(entry)
-  }
-
-  return result
-}
-
-function isUsableRelay(ma: Multiaddr, self: PeerId) {
+function isUsableRelay(ma: Multiaddr) {
   const tuples = ma.tuples()
-  const maPeerId = ma.getPeerId()
 
-  return (
-    tuples[0].length >= 2 &&
-    tuples[0][0] == CODE_IP4 &&
-    [CODE_UDP, CODE_TCP].includes(tuples[1][0]) &&
-    self.toB58String() !== maPeerId
-  )
+  return tuples[0].length >= 2 && tuples[0][0] == CODE_IP4 && [CODE_UDP, CODE_TCP].includes(tuples[1][0])
 }
 
 enum State {
@@ -129,7 +92,7 @@ class Listener extends EventEmitter implements InterfaceListener {
     private handler: ConnHandler | undefined,
     private upgrader: Upgrader,
     publicNodes: PublicNodesEmitter | undefined,
-    private initialNodes: Multiaddr[] | undefined,
+    private initialNodes: PeerStoreType[] = [],
     private peerId: PeerId,
     private _interface: string | undefined
   ) {
@@ -189,21 +152,42 @@ class Listener extends EventEmitter implements InterfaceListener {
    * Called once there is a new relay opportunity known
    * @param ma Multiaddr of node that is added as a relay opportunity
    */
-  private onNewRelay(ma: Multiaddr) {
-    if (this.publicNodes.length > MAX_RELAYS_PER_NODE) {
+  private onNewRelay(peer: PeerStoreType) {
+    if (this.publicNodes.length > MAX_RELAYS_PER_NODE || peer.id.equals(this.peerId)) {
       return
     }
 
-    // Also try "TCP addresses" as we expect that node is listening on TCP *and* UDP
-    if (!isUsableRelay(ma, this.peerId)) {
-      verbose(`Dropping potential STUN ${ma.toString()} because format is invalid or equal to own address`)
+    const usableAddresses = peer.multiaddrs.filter(isUsableRelay)
+
+    if (usableAddresses.length == 0) {
       return
+    }
+
+    let existingEntry = this.publicNodes.find((entry: NodeEntry) => entry.id.equals(peer.id))
+
+    if (existingEntry != undefined) {
+      const newAddresses = usableAddresses.filter((ma: Multiaddr) => !existingEntry!.multiaddrs.includes(ma))
+
+      if (newAddresses.length == 0) {
+        // Nothing added so we can stop
+        return
+      }
+
+      existingEntry.multiaddrs = newAddresses.concat(existingEntry.multiaddrs)
+    } else {
+      existingEntry = {
+        id: peer.id,
+        multiaddrs: peer.multiaddrs,
+        latency: Infinity
+      }
+
+      this.publicNodes.push(existingEntry)
     }
 
     if (this.state != State.LISTENING) {
-      once(this, 'listening').then(() => this.updatePublicNodes(ma))
+      once(this, 'listening').then(() => this.updatePublicNodes(peer.id))
     } else {
-      setImmediate(() => this.updatePublicNodes(ma))
+      setImmediate(() => this.updatePublicNodes(peer.id))
     }
   }
 
@@ -212,11 +196,9 @@ class Listener extends EventEmitter implements InterfaceListener {
    * @param ma Multiaddr of node that is considered to be offline now
    */
   protected onRemoveRelay(peer: PeerId) {
-    this.publicNodes = this.publicNodes.filter((entry: NodeEntry) => entry.peerId !== peer.toB58String())
+    this.publicNodes = this.publicNodes.filter((entry: NodeEntry) => !entry.id.equals(peer))
 
-    this.addrs.relays = this.publicNodes.map(
-      (entry: NodeEntry) => new Multiaddr(`/p2p/${entry.peerId}/p2p-circuit/p2p/${this.peerId}`)
-    )
+    this.addrs.relays = this.publicNodes.map(this.publicNodesToRelayMultiaddr.bind(this))
 
     log(
       `relay ${peer.toB58String()} ${red(`removed`)}. Current addrs:\n\t${this.addrs.relays
@@ -225,36 +207,43 @@ class Listener extends EventEmitter implements InterfaceListener {
     )
   }
 
-  protected async updatePublicNodes(ma: Multiaddr): Promise<void> {
+  protected async updatePublicNodes(peer: PeerId): Promise<void> {
     // Get previously known nodes and filter all nodes that have
     // either the same address (ip:port) or the same peerId
-    const publicNodes = removeNodeFromList(this.publicNodes, ma)
+    const entry = this.publicNodes.find((entry: NodeEntry) => entry.id.equals(peer))
+
+    if (entry == undefined) {
+      return
+    }
 
     const abort = new AbortController()
     const timeout = setTimeout(abort.abort.bind(abort), RELAY_CONTACT_TIMEOUT)
 
-    const result = await this.connectToRelay(ma, { signal: abort.signal })
+    const latency = await this.connectToRelay(entry.multiaddrs[0], { signal: abort.signal })
 
     clearTimeout(timeout)
 
     // Negative latency === timeout
-    if (result.latency < 0) {
+    if (latency < 0) {
+      this.publicNodes = this.publicNodes.filter((entry: NodeEntry) => !entry.id.equals(peer.id))
       return
     }
 
-    publicNodes.push(result)
+    entry.latency = latency
 
-    this.addrs.relays = publicNodes.map(
-      (entry: NodeEntry) => new Multiaddr(`/p2p/${entry.peerId}/p2p-circuit/p2p/${this.peerId}`)
-    )
+    this.publicNodes = this.publicNodes.sort(latencyCompare)
 
-    this.publicNodes = publicNodes.sort(latencyCompare)
+    this.addrs.relays = this.publicNodes.map(this.publicNodesToRelayMultiaddr.bind(this))
 
     log(
-      `relay ${ma.toString()} ${green(`added`)}. Current addrs:\n\t${this.addrs.relays
+      `relay ${peer.toB58String()} ${green(`added`)}. Current addrs:\n\t${this.addrs.relays
         .map((addr: Multiaddr) => addr.toString())
         .join(`\n\t`)}`
     )
+  }
+
+  private publicNodesToRelayMultiaddr(entry: NodeEntry) {
+    return new Multiaddr(`/p2p/${entry.id}/p2p-circuit/p2p/${this.peerId}`)
   }
 
   /**
@@ -574,6 +563,17 @@ class Listener extends EventEmitter implements InterfaceListener {
     this.addrs.external.push(externalMultiaddr)
   }
 
+  private getPotentialStunServers(): Multiaddr[] {
+    const result = []
+    for (const node of this.initialNodes.concat(this.publicNodes)) {
+      if (!node.id.equals(this.peerId)) {
+        result.push(...node.multiaddrs)
+      }
+    }
+
+    return result
+  }
+
   /**
    * Returns a list of STUN servers that we can use to determine
    * our own public IP address
@@ -582,15 +582,15 @@ class Listener extends EventEmitter implements InterfaceListener {
    * @returns a list of STUN servers, excluding ourself
    */
   private getUsableStunServers(port: number, host?: string): Multiaddr[] {
+    const potentialStunServers = this.getPotentialStunServers()
+
     if (host == undefined) {
-      return this.publicNodes.map((entry: NodeEntry) => entry.multiAddr)
+      return potentialStunServers
     }
 
     const usableStunServers: Multiaddr[] = []
 
-    for (const potentialStunServer of this.publicNodes != undefined && this.publicNodes.length > 0
-      ? this.publicNodes.map((entry: NodeEntry) => entry.multiAddr)
-      : this.initialNodes ?? []) {
+    for (const potentialStunServer of potentialStunServers) {
       let cOpts: { host: string; port: number }
       try {
         cOpts = potentialStunServer.toOptions()
@@ -647,20 +647,9 @@ class Listener extends EventEmitter implements InterfaceListener {
     return usableInterfaces[0].address
   }
 
-  private async connectToRelay(relay: Multiaddr, opts?: { signal: AbortSignal }): Promise<NodeEntry> {
-    let latency: number
+  private async connectToRelay(relay: Multiaddr, opts?: { signal: AbortSignal }): Promise<number> {
     let conn: Connection | undefined
     let maConn: MultiaddrConnection | undefined
-
-    const relayPeerId = relay.getPeerId()
-
-    const result = {
-      multiAddr: relay
-    } as NodeEntry
-
-    if (relayPeerId != null) {
-      result.peerId = relayPeerId
-    }
 
     const start = Date.now()
 
@@ -673,9 +662,7 @@ class Listener extends EventEmitter implements InterfaceListener {
     }
 
     if (maConn == undefined) {
-      result.latency = -1
-
-      return result
+      return -1
     }
 
     try {
@@ -698,12 +685,8 @@ class Listener extends EventEmitter implements InterfaceListener {
     }
 
     if (conn == undefined) {
-      result.latency = -1
-
-      return result
+      return -1
     }
-
-    latency = Date.now() - start
 
     this.trackConn(maConn)
 
@@ -711,9 +694,7 @@ class Listener extends EventEmitter implements InterfaceListener {
 
     this.emit('connection', conn)
 
-    result.latency = latency
-
-    return result
+    return Date.now() - start
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,7 +117,7 @@ class HoprConnect implements Transport {
     }
 
     if (this.__noDirectConnections) {
-      // Whenever we don't allow direct connection, we need to store
+      // Whenever we don't allow direct connections, we need to store
       // the known relays and make sure that we allow direct connections
       // to them.
       this.relayPeerIds = new Set<string>()

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,39 +5,42 @@ type Suffix = 'PublicNode'
 type AddEventName = `add${Suffix}`
 type RemoveEventName = `remove${Suffix}`
 
+export type PeerStoreType = { id: PeerId, multiaddrs: Multiaddr[] }
+type NewNodeListener = (peer: PeerStoreType) => void
+
 export interface PublicNodesEmitter {
   addListener(event: AddEventName | RemoveEventName, listener: () => void): this
-  addListener(event: AddEventName, listener: (newNode: Multiaddr) => void): this
+  addListener(event: AddEventName, listener: NewNodeListener): this
   addListener(event: RemoveEventName, listener: (removeNode: PeerId) => void): this
   addListener(event: string | symbol, listener: (...args: any[]) => void): this
 
   emit(event: AddEventName | RemoveEventName): boolean
-  emit(event: AddEventName, newNode: Multiaddr): boolean
+  emit(event: AddEventName, newNode: PeerStoreType): boolean
   emit(event: RemoveEventName, removeNode: PeerId): boolean
   emit(event: string | symbol, ...args: any[]): boolean
 
   on(event: AddEventName | RemoveEventName, listener: () => void): this
-  on(event: AddEventName, listener: (newNode: Multiaddr) => void): this
+  on(event: AddEventName, listener: NewNodeListener): this
   on(event: RemoveEventName, listener: (removeNode: PeerId) => void): this
   on(event: string | symbol, listener: (...args: any[]) => void): this
 
   once(event: AddEventName | RemoveEventName, listener: () => void): this
-  once(event: AddEventName, listener: (newNode: Multiaddr) => void): this
+  once(event: AddEventName, listener: NewNodeListener): this
   once(event: RemoveEventName, listener: (removeNode: PeerId) => void): this
   once(event: string | symbol, listener: (...args: any[]) => void): this
 
   prependListener(event: AddEventName | RemoveEventName, listener: () => void): this
-  prependListener(event: AddEventName, listener: (newNode: Multiaddr) => void): this
+  prependListener(event: AddEventName, listener: NewNodeListener): this
   prependListener(event: RemoveEventName, listener: (removeNode: PeerId) => void): this
   prependListener(event: string | symbol, listener: (...args: any[]) => void): this
 
   prependOnceListener(event: AddEventName | RemoveEventName, listener: () => void): this
-  prependOnceListener(event: AddEventName, listener: (newNode: Multiaddr) => void): this
+  prependOnceListener(event: AddEventName, listener: NewNodeListener): this
   prependOnceListener(event: RemoveEventName, listener: (removeNode: PeerId) => void): this
   prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this
 
   removeListener(event: AddEventName | RemoveEventName, listener: () => void): this
-  removeListener(event: AddEventName, listener: (newNode: Multiaddr) => void): this
+  removeListener(event: AddEventName, listener: NewNodeListener): this
   removeListener(event: RemoveEventName, listener: (removeNode: PeerId) => void): this
   removeListener(event: string | symbol, listener: (...args: any[]) => void): this
 }

--- a/src/webrtc/upgrader.ts
+++ b/src/webrtc/upgrader.ts
@@ -52,7 +52,10 @@ class WebRTCUpgrader {
     const iceServers: RTCIceServer[] = []
     for (const entry of this.publicNodes) {
       iceServers.push({
-        urls: entry.multiaddrs.map(multiaddrToIceServer)
+        urls:
+          entry.multiaddrs.length == 1
+            ? multiaddrToIceServer(entry.multiaddrs[0])
+            : entry.multiaddrs.map(multiaddrToIceServer)
       })
     }
 

--- a/src/webrtc/upgrader.ts
+++ b/src/webrtc/upgrader.ts
@@ -52,7 +52,7 @@ class WebRTCUpgrader {
     const iceServers: RTCIceServer[] = []
     for (const entry of this.publicNodes) {
       iceServers.push({
-        urls: entry.multiaddrs.map(multiaddrToIceServer).join(',')
+        urls: entry.multiaddrs.map(multiaddrToIceServer)
       })
     }
 

--- a/src/webrtc/upgrader.ts
+++ b/src/webrtc/upgrader.ts
@@ -2,7 +2,7 @@ import SimplePeer from 'simple-peer'
 import debug from 'debug'
 
 import type { Multiaddr } from 'multiaddr'
-import type { PublicNodesEmitter } from '../types'
+import type { PublicNodesEmitter, PeerStoreType } from '../types'
 import { CODE_IP4, CODE_TCP, CODE_UDP } from '../constants'
 import type PeerId from 'peer-id'
 
@@ -31,33 +31,16 @@ function isUsableMultiaddr(tuples: ReturnType<Multiaddr['tuples']>) {
   return tuples[0].length >= 2 && tuples[0][0] == CODE_IP4 && [CODE_UDP, CODE_TCP].includes(tuples[1][0])
 }
 
-function removeMultiaddrFromList(iceServers: RTCIceServer[], iceServerUrl: string): RTCIceServer[] {
-  let result = []
-  for (const iceServer of iceServers) {
-    if (Array.isArray(iceServer.urls)) {
-      if (!iceServer.urls.some((url: string) => iceServerUrl === url)) {
-        result.push(iceServer)
-      }
-      continue
-    }
-
-    if (iceServer.urls !== iceServerUrl) {
-      result.push(iceServer)
-    }
-  }
-
-  return result
-}
-
 /**
  * Encapsulate configuration used to create WebRTC instances
  */
 class WebRTCUpgrader {
   public rtcConfig?: RTCConfiguration
-  private publicNodes: Map<string, Multiaddr[]>
+  private publicNodes: PeerStoreType[]
 
-  constructor(publicNodes?: PublicNodesEmitter, initialNodes?: Multiaddr[]) {
-    this.publicNodes = new Map<string, Multiaddr[]>()
+  constructor(publicNodes?: PublicNodesEmitter, initialNodes?: PeerStoreType[]) {
+    this.publicNodes = []
+
     initialNodes?.forEach(this.onNewPublicNode.bind(this))
 
     publicNodes?.on('addPublicNode', this.onNewPublicNode.bind(this))
@@ -65,7 +48,18 @@ class WebRTCUpgrader {
     publicNodes?.on('removePublicNode', this.onOfflineNode.bind(this))
   }
 
-  private onNewPublicNode(ma: Multiaddr) {
+  private publicNodesToRTCServers(): RTCIceServer[] {
+    const iceServers: RTCIceServer[] = []
+    for (const entry of this.publicNodes) {
+      iceServers.push({
+        urls: entry.multiaddrs.map(multiaddrToIceServer).join(',')
+      })
+    }
+
+    return iceServers
+  }
+
+  private onNewPublicNode(peer: PeerStoreType) {
     if (
       this.rtcConfig != undefined &&
       this.rtcConfig.iceServers != undefined &&
@@ -74,36 +68,45 @@ class WebRTCUpgrader {
       return
     }
 
-    const tuples = ma.tuples()
+    let found = this.publicNodes.find((entry: PeerStoreType) => entry.id.equals(peer.id))
 
-    // Also try "TCP addresses" as we expect that node is listening on TCP *and* UDP
-    if (!isUsableMultiaddr(tuples)) {
-      verbose(`Dropping potential STUN ${ma.toString()} because format is invalid`)
-      return
-    }
+    if (found == undefined) {
+      const usableAddresses = peer.multiaddrs.filter((ma: Multiaddr) => {
+        const tuples = ma.tuples()
 
-    const maPeerId = ma.getPeerId() ?? 'unknownPeer'
+        return isUsableMultiaddr(tuples)
+      })
 
-    let found = this.publicNodes.get(maPeerId)
-    if (found) {
-      if (!found.some((existing: Multiaddr) => existing.equals(ma))) {
-        found.push(ma)
+      if (usableAddresses.length > 0) {
+        this.publicNodes.unshift({ id: peer.id, multiaddrs: usableAddresses })
       }
     } else {
-      found = [ma]
+      let before = found.multiaddrs.length
+
+      for (const ma of peer.multiaddrs) {
+        const tuples = ma.tuples()
+
+        // Also try "TCP addresses" as we expect that node is listening on TCP *and* UDP
+        if (!isUsableMultiaddr(tuples)) {
+          verbose(`Dropping potential STUN ${ma.toString()} because format is invalid`)
+          continue
+        }
+
+        if (found.multiaddrs.some((existing: Multiaddr) => existing.equals(ma))) {
+          continue
+        }
+
+        found.multiaddrs.unshift(ma)
+      }
+
+      if (found.multiaddrs.length == before) {
+        return
+      }
     }
-
-    this.publicNodes.set(maPeerId, found)
-
-    const iceServerUrl = multiaddrToIceServer(ma)
-
-    const iceServers = removeMultiaddrFromList(this.rtcConfig?.iceServers ?? [], iceServerUrl)
-
-    iceServers.unshift({ urls: iceServerUrl })
 
     this.rtcConfig = {
       ...this.rtcConfig,
-      iceServers
+      iceServers: this.publicNodesToRTCServers()
     }
   }
 
@@ -112,15 +115,11 @@ class WebRTCUpgrader {
       return
     }
 
-    let found = this.publicNodes.get(peer.toB58String())
-    if (found) {
-      let iceServers = this.rtcConfig.iceServers
-      for (const ma of found) {
-        iceServers = removeMultiaddrFromList(iceServers, multiaddrToIceServer(ma))
-      }
-      this.rtcConfig.iceServers = iceServers
+    this.publicNodes = this.publicNodes.filter((entry: PeerStoreType) => !entry.id.equals(peer))
 
-      this.publicNodes.delete(peer.toB58String())
+    this.rtcConfig = {
+      ...this.rtcConfig,
+      iceServers: this.publicNodesToRTCServers()
     }
   }
 

--- a/src/webrtc/upgrader.ts
+++ b/src/webrtc/upgrader.ts
@@ -71,9 +71,9 @@ class WebRTCUpgrader {
       return
     }
 
-    let found = this.publicNodes.find((entry: PeerStoreType) => entry.id.equals(peer.id))
+    let entry = this.publicNodes.find((entry: PeerStoreType) => entry.id.equals(peer.id))
 
-    if (found == undefined) {
+    if (entry == undefined) {
       const usableAddresses = peer.multiaddrs.filter((ma: Multiaddr) => {
         const tuples = ma.tuples()
 
@@ -84,7 +84,7 @@ class WebRTCUpgrader {
         this.publicNodes.unshift({ id: peer.id, multiaddrs: usableAddresses })
       }
     } else {
-      let before = found.multiaddrs.length
+      let before = entry.multiaddrs.length
 
       for (const ma of peer.multiaddrs) {
         const tuples = ma.tuples()
@@ -95,14 +95,14 @@ class WebRTCUpgrader {
           continue
         }
 
-        if (found.multiaddrs.some((existing: Multiaddr) => existing.equals(ma))) {
+        if (entry.multiaddrs.some((existing: Multiaddr) => existing.equals(ma))) {
           continue
         }
 
-        found.multiaddrs.unshift(ma)
+        entry.multiaddrs.unshift(ma)
       }
 
-      if (found.multiaddrs.length == before) {
+      if (entry.multiaddrs.length == before) {
         return
       }
     }

--- a/tests/node.ts
+++ b/tests/node.ts
@@ -7,14 +7,16 @@ import { NOISE } from 'libp2p-noise'
 
 const MPLEX = require('libp2p-mplex')
 
-import { HoprConnect, HoprConnectOptions } from '../src'
+import { HoprConnect } from '../src'
+import type { HoprConnectOptions } from '../src'
 import { Multiaddr } from 'multiaddr'
 import pipe from 'it-pipe'
 import yargs from 'yargs/yargs'
 import { peerIdForIdentity, identityFromPeerId } from './identities'
-import PeerId from 'peer-id'
-import LibP2P from 'libp2p'
-import { WriteStream } from 'node:fs'
+import type PeerId from 'peer-id'
+import type LibP2P from 'libp2p'
+import type { WriteStream } from 'node:fs'
+import type { PeerStoreType } from '../src/types'
 
 const TEST_PROTOCOL = '/hopr-connect/test/0.0.1'
 
@@ -71,7 +73,7 @@ async function startNode({
 }: {
   peerId: PeerId
   port: number
-  bootstrapAddress?: Multiaddr
+  bootstrapAddress?: PeerStoreType
   noDirectConnections: boolean
   noWebRTCUpgrade: boolean
   pipeFileStream?: WriteStream
@@ -259,11 +261,14 @@ async function main() {
     })
     .parseSync()
 
-  let bootstrapAddress: Multiaddr | undefined
+  let bootstrapAddress: PeerStoreType | undefined
 
   if (argv.bootstrapPort != null && argv.bootstrapIdentityName != null) {
     const bootstrapPeerId = await peerIdForIdentity(argv.bootstrapIdentityName)
-    bootstrapAddress = new Multiaddr(`/ip4/127.0.0.1/tcp/${argv.bootstrapPort}/p2p/${bootstrapPeerId.toB58String()}`)
+    bootstrapAddress = {
+      id: bootstrapPeerId,
+      multiaddrs: [new Multiaddr(`/ip4/127.0.0.1/tcp/${argv.bootstrapPort}/p2p/${bootstrapPeerId.toB58String()}`)]
+    }
   }
   const peerId = await peerIdForIdentity(argv.identityName)
 


### PR DESCRIPTION
Changes:
- event signature `addPublicNode` -> from `peer: Multiaddr` to `{ id: PeerId, multiaddrs: Multiaddr[] }`
- remove all addresses of offline nodes
- store potential relays grouped by their PeerId 

Breaking change:
- always require a PeerId when announcing a new public node