### PR TITLE
Ambiguous STUN responses

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,4 +29,4 @@ jobs:
 
       - name: Test
         run: |
-          DEBUG=hopr* yarn test
+          yarn test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,4 +29,4 @@ jobs:
 
       - name: Test
         run: |
-          yarn test
+          DEBUG=hopr* yarn test

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "spawn-test-node": "ts-node tests/node.ts",
     "clean": "rm -Rf ./lib",
     "build": "yarn clean && tsc -p .",
-    "test": "yarn node --trace-warnings --unhandled-rejections=strict node_modules/.bin/mocha --reporter=tap --full-trace --exit",
+    "test": "DEBUG=hopr* yarn node --trace-warnings --unhandled-rejections=strict node_modules/.bin/mocha --reporter=tap --full-trace --exit",
     "prepublishOnly": "yarn build"
   },
   "dependencies": {
@@ -72,7 +72,7 @@
       "ts"
     ],
     "spec": [
-      "src/**/*.spec.ts"
+      "src/base/stun.spec.ts"
     ],
     "require": [
       "ts-node/register"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "spawn-test-node": "ts-node tests/node.ts",
     "clean": "rm -Rf ./lib",
     "build": "yarn clean && tsc -p .",
-    "test": "DEBUG=hopr* yarn node --trace-warnings --unhandled-rejections=strict node_modules/.bin/mocha --reporter=tap --full-trace --exit",
+    "test": "yarn node --trace-warnings --unhandled-rejections=strict node_modules/.bin/mocha --reporter=tap --full-trace --exit",
     "prepublishOnly": "yarn build"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
       "ts"
     ],
     "spec": [
-      "src/base/stun.spec.ts"
+      "src/**/*.spec.ts"
     ],
     "require": [
       "ts-node/register"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "scripts": {
     "lint": "prettier --check .",
     "lint:fix": "prettier --write .",
+    "spawn-test-node": "ts-node tests/node.ts",
     "clean": "rm -Rf ./lib",
     "build": "yarn clean && tsc -p .",
     "test": "yarn node --trace-warnings --unhandled-rejections=strict node_modules/.bin/mocha --reporter=tap --full-trace --exit",

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -37,9 +37,7 @@ function start_node {
     declare rest_args=${@:4}
 
     DEBUG=hopr-connect*,simple-peer \
-    yarn dlx \
-    ts-node \
-        "${filename}" \
+    yarn run spawn-test-node \
         > "${log_file}" \
         ${rest_args} \
         --script "${script}" \

--- a/src/base/stun.spec.ts
+++ b/src/base/stun.spec.ts
@@ -93,7 +93,7 @@ describe('test STUN', function () {
     )
   })
 
-  it.only('should perform a STUN request', async function () {
+  it('should perform a STUN request', async function () {
     const multiAddrs = servers
       .slice(1)
       .map((server: ServerType) => Multiaddr.fromNodeAddress(nodeToMultiaddr(server.socket.address()), 'udp'))

--- a/src/base/stun.spec.ts
+++ b/src/base/stun.spec.ts
@@ -7,7 +7,7 @@ import {
   PUBLIC_STUN_SERVERS,
   STUN_TIMEOUT
 } from './stun'
-import { nodeToMultiaddr } from '../utils'
+import { ipToU8aAddress, isLocalhost, isPrivateAddress, nodeToMultiaddr } from '../utils'
 import { Multiaddr } from 'multiaddr'
 import assert from 'assert'
 import { once } from 'events'
@@ -100,9 +100,17 @@ describe('test STUN', function () {
 
     const result = await getExternalIp(multiAddrs, servers[0].socket)
 
+    // FIXME this fails when running behind a birectional NAT
     assert(result != undefined, `STUN request must be successful`)
 
-    assert(servers[0].socket.address().port === result.port, 'Ports should match')
+    const u8aAddress = ipToU8aAddress(result.address, 'IPv4')
+
+    // FIXME this fails when running behind a birectional NAT
+    assert(
+      !isLocalhost(u8aAddress, 'IPv4') && !isPrivateAddress(u8aAddress, 'IPv4'),
+      'Result must be a public IPv4 address'
+    )
+
     /*
      // DISABLED - with IP4 the address changes from 0.0.0.0 to 127.0.0.1
      // IPV6 doesn't work at present.

--- a/src/base/stun.spec.ts
+++ b/src/base/stun.spec.ts
@@ -93,8 +93,8 @@ describe('test STUN', function () {
     )
   })
 
-  it('should perform a STUN request', async function () {
-    const multiAddrs = servers.map((server: ServerType) =>
+  it.only('should perform a STUN request', async function () {
+    const multiAddrs = servers.slice(1).map((server: ServerType) =>
       Multiaddr.fromNodeAddress(nodeToMultiaddr(server.socket.address()), 'udp')
     )
 

--- a/src/base/stun.spec.ts
+++ b/src/base/stun.spec.ts
@@ -100,12 +100,12 @@ describe('test STUN', function () {
 
     const result = await getExternalIp(multiAddrs, servers[0].socket)
 
-    // FIXME this fails when running behind a birectional NAT
+    // FIXME this fails when running behind a bidirectional NAT
     assert(result != undefined, `STUN request must be successful`)
 
     const u8aAddress = ipToU8aAddress(result.address, 'IPv4')
 
-    // FIXME this fails when running behind a birectional NAT
+    // FIXME this fails when running behind a bidirectional NAT
     assert(
       !isLocalhost(u8aAddress, 'IPv4') && !isPrivateAddress(u8aAddress, 'IPv4'),
       'Result must be a public IPv4 address'
@@ -194,7 +194,10 @@ describe('test STUN', function () {
       true
     )
 
-    assert(responseWhenRunningLocally == undefined, `Ambiguous results from local STUN servers should `)
+    assert(
+      responseWhenRunningLocally == undefined,
+      `Ambiguous results from local STUN servers should not lead to successful STUN response`
+    )
 
     await Promise.all(tweakedServers.map(closeSTUNServer))
   })

--- a/src/base/stun.spec.ts
+++ b/src/base/stun.spec.ts
@@ -27,7 +27,7 @@ type ServerType = {
  * @param address fake address
  * @returns STUN server answering with falsy responses
  */
-async function getAmbigousSTUNServer(port: number, address?: string) {
+async function getAmbiguousSTUNServer(port: number, address?: string) {
   const socket = dgram.createSocket('udp4')
 
   const listeningPromise = once(socket, 'listening')
@@ -169,7 +169,7 @@ describe('test STUN', function () {
     const BASE_PUBLIC_ADDRESS = `1.2.3.`
     const tweakedServers = await Promise.all(
       Array.from({ length: 2 }, (_, index: number) =>
-        getAmbigousSTUNServer(index, BASE_PUBLIC_ADDRESS.concat(index.toString()))
+        getAmbiguousSTUNServer(index, BASE_PUBLIC_ADDRESS.concat(index.toString()))
       )
     )
 
@@ -178,14 +178,14 @@ describe('test STUN', function () {
       servers[0].socket
     )
 
-    assert(response == undefined, `Ambigous results from local STUN servers must detected as bidirectional NAT`)
+    assert(response == undefined, `Ambiguous results from local STUN servers must detected as bidirectional NAT`)
 
     await Promise.all(tweakedServers.map(closeSTUNServer))
   })
 
   it('should understand ambiguous results when running in local testnet', async function () {
     const tweakedServers = await Promise.all(
-      Array.from({ length: 2 }, (_, index: number) => getAmbigousSTUNServer(index))
+      Array.from({ length: 2 }, (_, index: number) => getAmbiguousSTUNServer(index))
     )
 
     const responseWhenRunningLocally = await getExternalIp(

--- a/src/base/stun.ts
+++ b/src/base/stun.ts
@@ -42,6 +42,7 @@ export const DEFAULT_PARALLEL_STUN_CALLS = 4
  * @param socket Node.JS socket to use
  * @param data received packet
  * @param rinfo Addr+Port of the incoming connection
+ * @param __fakeRInfo [testing] overwrite incoming information to intentionally send misleading STUN response
  */
 export function handleStunRequest(socket: Socket, data: Buffer, rinfo: RemoteInfo, __fakeRInfo?: RemoteInfo): void {
   const req = stun.createBlank()
@@ -94,6 +95,7 @@ type Request = {
  *
  * @param multiAddrs Multiaddrs to use as STUN servers
  * @param socket Node.JS socket to use for the STUN request
+ * @param runningLocally set to true when running a local testnet
  */
 export async function getExternalIp(
   multiAddrs: Multiaddr[] | undefined,

--- a/src/base/stun.ts
+++ b/src/base/stun.ts
@@ -315,8 +315,16 @@ function getUsableResults(results: Request[], runningLocally = false): Request[]
         break
       case 'IPv4':
         const u8aAddr = ipToU8aAddress(result.response.address, 'IPv4')
-        // If running locally, get only local addresses,
-        // otherwise only get public addresses
+        // Disitinguish two use cases:
+        // Unit tests:
+        // - run several instances on one machine, hence STUN response is expected to be
+        //   'localhost:somePort'
+        // CI tests / large E2E tests:
+        // - run several instances on multiple machines running in the *same* local network
+        //   hence STUN response is expected to be a local address
+        // Disclaimer:
+        // the mixed use case, meaning some instances running on the same machine and some
+        // instances running on machines in the same network is not expected
         if ((isPrivateAddress(u8aAddr, 'IPv4') || isLocalhost(u8aAddr, 'IPv4')) == runningLocally) {
           filtered.push(result)
         }


### PR DESCRIPTION
Changes:
- introduce 2 modes: local testnet for CI integration tests, public network
- improve testing by introducing faked STUN servers that produce ambiguous STUN responses
- fix ts-node running in wrong environment

Local mode STUN:
- use local STUN servers and treat their response as public addresses
- used for integration tests

Normal mode STUN:
- responses from STUN servers that contain local addresses are filtered and not used to determine own public IP address
- if only local STUN servers or no STUN servers are known or own STUN servers only return local addresses, try external STUN servers

Partially fixes #285 - additional testing required